### PR TITLE
feat: create common listSubstates provider method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",
-        "@tariproject/wallet_jrpc_client": "1.0.5"
+        "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development",
+        "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -109,13 +110,14 @@
     },
     "node_modules/@tariproject/typescript-bindings": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tariproject/typescript-bindings/-/typescript-bindings-1.0.1.tgz",
-      "integrity": "sha512-VtOtuX54E2HUYF+OWvjtnUSuuigQWwdHTHMRmpcaIRtf49BgqBuP1NsQGKeAfvBxifBvWwV2tAkFZzheSmeY9A=="
+      "resolved": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development",
+      "integrity": "sha512-fZ7vF/Yp/C7+dG1CRXbrWhLboOYxBy+bSA99qVanPVYgx1qJDxVC5uSvQFkYRnOH5jNlQu6PJMN2ZXDDAr+6UA=="
     },
     "node_modules/@tariproject/wallet_jrpc_client": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tariproject/wallet_jrpc_client/-/wallet_jrpc_client-1.0.5.tgz",
-      "integrity": "sha512-8nDWP+ovjfXZJTlP5ro0FzY53dwXXPj3OCmc6nQqTlKD/VH3kqhD63VdfgFpQb28ZRV5jf8wQ5D/xxTxJOIT5Q==",
+      "resolved": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
+      "integrity": "sha512-EKfccdiYFbKLTOTYCaKAINfGzEb2h1QGBa+QRvQXlqYAKVA0em0LpoY0+AeLGlABTX0PFxDjwRT7NloSp4R0vg==",
+      "hasInstallScript": true,
       "dependencies": {
         "@tariproject/typescript-bindings": "1.0.1"
       }
@@ -154,9 +156,9 @@
       "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -354,12 +356,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -430,18 +435,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-dir": {
@@ -648,13 +641,10 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -683,15 +673,15 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -722,9 +712,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/webextension-polyfill": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
-      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
+      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q=="
     },
     "node_modules/webextension-polyfill-ts": {
       "version": "0.25.0",
@@ -744,12 +734,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/providers": "^9.0.0",
-    "@tariproject/wallet_jrpc_client": "1.0.5"
+    "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
+    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+import { SubstateType } from "@tariproject/typescript-bindings";
 import {
     Account,
     SubmitTransactionRequest,
@@ -5,6 +6,7 @@ import {
     SubmitTransactionResponse,
     VaultBalances,
     TemplateDefinition, Substate,
+    ListSubstatesResponse,
 } from "./types";
 
 export interface TariProvider {
@@ -17,4 +19,5 @@ export interface TariProvider {
     getTemplateDefinition(template_address: string): Promise<TemplateDefinition>
     getPublicKey(branch: string, index: number): Promise<string>;
     getConfidentialVaultBalances(viewKeyId: number, vaultId: string, min: number | null, max: number | null): Promise<VaultBalances>;
+    listSubstates(filter_by_template: string | null, filter_by_type: SubstateType | null, limit: number | null, offset: number | null): Promise<ListSubstatesResponse>;
 }

--- a/src/providers/metamask/index.ts
+++ b/src/providers/metamask/index.ts
@@ -5,11 +5,13 @@ import {
     TransactionStatus,
     SubmitTransactionResponse,
     VaultBalances, TemplateDefinition, Substate,
+    ListSubstatesResponse,
 } from "../types";
 import {MetaMaskInpageProvider} from '@metamask/providers';
 import {connectSnap, getSnap, isFlask, Snap} from "./utils";
 import {Maybe} from "@metamask/providers/dist/utils";
 import {Account} from "../types";
+import { SubstateType } from "@tariproject/typescript-bindings";
 
 export const MetamaskNotInstalled = 'METAMASK_NOT_INSTALLED';
 export const MetamaskIsNotFlask = 'METAMASK_IS_NOT_FLASK';
@@ -80,6 +82,17 @@ export class MetamaskTariProvider implements TariProvider {
     async getSubstate(substate_address: string): Promise<Substate> {
         const {substate, address: substate_id, version} = await this.metamaskRequest<any>('getSubstate', { substate_address });
         return {value: substate, address: {substate_id, version}}
+    }
+
+    async listSubstates(filter_by_template: string | null, filter_by_type: SubstateType | null, limit: number | null, offset: number | null): Promise<ListSubstatesResponse> {
+        const res = await this.metamaskRequest('listSubstates', {
+            filter_by_template,
+            filter_by_type,
+            limit,
+            offset,
+        }) as any;
+
+        return res;
     }
 
     async submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse> {

--- a/src/providers/tari_universe/provider.ts
+++ b/src/providers/tari_universe/provider.ts
@@ -7,10 +7,11 @@ import {
   Substate,
   TemplateDefinition,
   VaultBalances,
+  ListSubstatesResponse,
 } from "../types";
 import { ProviderRequest, ProviderMethodNames, ProviderReturnType, ProviderResponse } from "./types";
 import { TariProvider } from "../index";
-import { AccountsGetBalancesResponse } from "@tariproject/wallet_jrpc_client";
+import { AccountsGetBalancesResponse, SubstateType } from "@tariproject/wallet_jrpc_client";
 
 export type TariUniverseProviderParameters = {
   permissions: TariPermissions;
@@ -82,6 +83,10 @@ export class TariUniverseProvider implements TariProvider {
       methodName: "getSubstate",
       args: [substate_id],
     });
+  }
+
+  public async listSubstates(_filter_by_template: string | null, _filter_by_type: SubstateType | null, _limit: number | null, _offset: number | null): Promise<ListSubstatesResponse> {
+    throw new Error("Method not implemented.");
   }
 
   public async submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse> {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,3 +1,10 @@
+export type SubstateMetadata = {
+  substate_id: string;
+  module_name: string | null;
+  version: number;
+  template_address: string | null;
+}
+
 export type SubstateRequirement = {
   substate_id: string;
   version?: number | null;
@@ -64,3 +71,7 @@ export interface Substate {
     version: number;
   };
 }
+
+export type ListSubstatesResponse = {
+  substates: Array<SubstateMetadata>;
+};

--- a/src/providers/wallet_daemon/provider.ts
+++ b/src/providers/wallet_daemon/provider.ts
@@ -7,6 +7,7 @@ import {
     TransactionStatus,
     SubmitTransactionResponse,
     VaultBalances, TemplateDefinition, Substate,
+    ListSubstatesResponse,
 } from "../types";
 import {Account} from "../types";
 import {
@@ -183,15 +184,23 @@ export class WalletDaemonTariProvider implements TariProvider {
         return {balances: res.balances as unknown as Map<string, number | null>};
     }
 
-    public async listSubstates(
-        template: string | null,
-        substateType: SubstateType | null
-    ) {
+    public async listSubstates(filter_by_template: string | null, filter_by_type: SubstateType | null, limit: number | null, offset: number | null): Promise<ListSubstatesResponse>
+    {
         const resp = await this.client.substatesList({
-            filter_by_template: template,
-            filter_by_type: substateType
+            filter_by_template,
+            filter_by_type,
+            limit,
+            offset
         } as SubstatesListRequest);
-        return resp.substates as any[];
+
+        const substates = resp.substates.map((s) =>  ({
+            substate_id: substateIdToString(s.substate_id),
+            module_name: s.module_name,
+            version: s.version,
+            template_address: s.template_address
+        }));
+
+        return {substates};
     }
 }
 


### PR DESCRIPTION
After https://github.com/tari-project/tari-dan/pull/1060 and https://github.com/tari-project/tari-snap/pull/19 the functionality for substate listing is now the same for both wallet daemon and metamask snap.

This PR creates a common `listSubstate` method in the `provider` interface, with the corresponding implementation for each of the providers (wallet daemon and snap). For the `tari_universe` provider the method was left unimplemented, it would need to be done in a future PR.

For convenience, this PR also sets the tari `npm` depedencies using `gitpkg` to always use the latest version of the bindings. This is meant as a temporary solution until npm package deployment is integrated into the tari-dan CI.