### PR TITLE
feat(tari-universe): Add support for rejected transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@metamask/providers": "^9.0.0",
     "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
-    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development"
+    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development&scripts.postinstall=npm%20run%tsc"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@metamask/providers": "^9.0.0",
     "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
-    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development&scripts.postinstall=npm%20run%tsc"
+    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development&scripts.postinstall=npm%20run%20tsc"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,23 +1,49 @@
-import { SubstateType } from "@tariproject/typescript-bindings";
+import type { SubstateType } from "@tariproject/typescript-bindings";
 import {
-    Account,
-    SubmitTransactionRequest,
-    TransactionResult,
-    SubmitTransactionResponse,
-    VaultBalances,
-    TemplateDefinition, Substate,
-    ListSubstatesResponse,
+  Account,
+  SubmitTransactionRequest,
+  TransactionResult,
+  SubmitTransactionResponse,
+  VaultBalances,
+  TemplateDefinition,
+  Substate,
+  ListSubstatesResponse,
 } from "./types";
+import { ProviderMethods, ProviderMethodNames, ProviderReturnType } from "./tari_universe/types";
+
+export type {
+  Account,
+  SubmitTransactionRequest,
+  TransactionResult,
+  SubmitTransactionResponse,
+  VaultBalances,
+  TemplateDefinition,
+  Substate,
+  ListSubstatesResponse,
+  ProviderMethods,
+  ProviderMethodNames,
+  ProviderReturnType,
+};
 
 export interface TariProvider {
-    providerName: string;
-    isConnected(): boolean;
-    getAccount(): Promise<Account>;
-    getSubstate(substate_address: string): Promise<Substate>,
-    submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse>
-    getTransactionResult(transactionId: string): Promise<TransactionResult>
-    getTemplateDefinition(template_address: string): Promise<TemplateDefinition>
-    getPublicKey(branch: string, index: number): Promise<string>;
-    getConfidentialVaultBalances(viewKeyId: number, vaultId: string, min: number | null, max: number | null): Promise<VaultBalances>;
-    listSubstates(filter_by_template: string | null, filter_by_type: SubstateType | null, limit: number | null, offset: number | null): Promise<ListSubstatesResponse>;
+  providerName: string;
+  isConnected(): boolean;
+  getAccount(): Promise<Account>;
+  getSubstate(substate_address: string): Promise<Substate>;
+  submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse>;
+  getTransactionResult(transactionId: string): Promise<TransactionResult>;
+  getTemplateDefinition(template_address: string): Promise<TemplateDefinition>;
+  getPublicKey(branch: string, index: number): Promise<string>;
+  getConfidentialVaultBalances(
+    viewKeyId: number,
+    vaultId: string,
+    min: number | null,
+    max: number | null,
+  ): Promise<VaultBalances>;
+  listSubstates(
+    filter_by_template: string | null,
+    filter_by_type: SubstateType | null,
+    limit: number | null,
+    offset: number | null,
+  ): Promise<ListSubstatesResponse>;
 }

--- a/src/providers/tari_universe/provider.ts
+++ b/src/providers/tari_universe/provider.ts
@@ -39,8 +39,12 @@ export class TariUniverseProvider implements TariProvider {
     req: Omit<ProviderRequest<MethodName>, "id">,
   ): Promise<ProviderReturnType<MethodName>> {
     const id = ++this.__id;
-    return new Promise<ProviderReturnType<MethodName>>(function (resolve, _reject) {
+    return new Promise<ProviderReturnType<MethodName>>(function (resolve, reject) {
       const event_ref = function (resp: MessageEvent<ProviderResponse<MethodName>>) {
+        if (resp.data.resultError) {
+          window.removeEventListener("message", event_ref);
+          reject(resp.data.resultError);
+        }
         if (resp && resp.data && resp.data.id && resp.data.id == id && resp.data.type === "provider-call") {
           window.removeEventListener("message", event_ref);
           resolve(resp.data.result);

--- a/src/providers/tari_universe/types.ts
+++ b/src/providers/tari_universe/types.ts
@@ -29,4 +29,5 @@ export type ProviderResponse<T extends ProviderMethodNames> = {
   id: number;
   type: "provider-call";
   result: ProviderReturnType<T>;
+  resultError?: string;
 };


### PR DESCRIPTION
Description
---
Add field `resultError` to the Tari Universe provider response. If it is present in the response than that means the provider call failed and we should return `reject` from provider promise. 

Motivation and Context
---
After adding transaction confirmation users can decide to cancel transaction. This requires from provider to handle case where provider denies any transaction to be run.
![image](https://github.com/tari-project/tari.js/assets/20818447/4f9a7478-fc96-45cf-adcd-8e6101def64e)


How Has This Been Tested?
---
Tested manually

What process can a PR reviewer use to test or verify this change?
---
- Setup Tari Universe
- Run [faucet tapplet](https://github.com/MCozhusheck/faucet-tapplet) in dev mode
- Add this tapplet and click around to see if it's working

Both Tari Universe and faucet tapplet requires tari.js so tester needs to add it as local dependency in package.json

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
