### PR TITLE
chore: add github workflow for npm publish

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,9 +3,18 @@
 # See https://github.com/marketplace/actions/npm-publish for more information
 name: Publish Package to npmjs
 
+# TODO: after confirming that the action works, set the trigger on "main" branch commits instead of PRs 
+# on:
+#   push:
+#     branches: main
+
 on:
-  push:
-    branches: main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 jobs:
   publish:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -7,14 +7,6 @@ on:
   push:
     branches: main
 
-on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - edited
-      - synchronize
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,11 +16,7 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
-      - run: npm test
       - uses: JS-DevTools/npm-publish@v3
-        id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-      - if: ${{ steps.publish.outputs.type }}
-        run: echo "Published to NPM registry '${{ steps.publish.outputs.name }}' version '${{ steps.publish.outputs.version }}'"
       

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,26 @@
+---
+# Publishing the package to the npm registry when the version number changes
+# See https://github.com/marketplace/actions/npm-publish for more information
+name: Publish Package to npmjs
+
+on:
+  push:
+    branches: main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v3
+        id: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - if: ${{ steps.publish.outputs.type }}
+        run: echo "Published to NPM registry '${{ steps.publish.outputs.name }}' version '${{ steps.publish.outputs.version }}'"
+      

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - run: npm run build
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: 'public'
       

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,10 +3,9 @@
 # See https://github.com/marketplace/actions/npm-publish for more information
 name: Publish Package to npmjs
 
-# TODO: after confirming that the action works, set the trigger on "main" branch commits instead of PRs 
-# on:
-#   push:
-#     branches: main
+on:
+  push:
+    branches: main
 
 on:
   pull_request:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/tarijs",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "@tariproject/tarijs",
+  "name": "@tari-project/tarijs",
   "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@tariproject/tarijs",
+      "name": "@tari-project/tarijs",
       "version": "0.1.19",
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",
-        "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development",
-        "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build"
+        "@tari-project/typescript-bindings": "^1.0.3",
+        "@tari-project/wallet_jrpc_client": "^1.0.7"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -108,18 +108,17 @@
         }
       }
     },
-    "node_modules/@tariproject/typescript-bindings": {
-      "version": "1.0.1",
-      "resolved": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development",
-      "integrity": "sha512-DSxDpGTa0+tTBZajMMPDEPv4iBrniqxktLHdQSLJwopzwL0QlafonWJnu+xwCdEG/l7ZgWvLCeiDpWIsXktkBQ=="
+    "node_modules/@tari-project/typescript-bindings": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tari-project/typescript-bindings/-/typescript-bindings-1.0.3.tgz",
+      "integrity": "sha512-CWJAxXgorgDXWO3U3gg/LOB3KoYgrq63zYwR1Z0tEZW0HkkA4BKlyHywRn/WpgvoCCAmAMOM6pO2jV5x1iqM/w=="
     },
-    "node_modules/@tariproject/wallet_jrpc_client": {
-      "version": "1.0.5",
-      "resolved": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
-      "integrity": "sha512-1QIk5AeCq0lL+3iPiVKcFS5KmMsgknen/4Am8lUo2JyGxgzEJA0zzXJiwCb2uRAeeKZ14rADPv3cNtb3MAYNhg==",
-      "hasInstallScript": true,
+    "node_modules/@tari-project/wallet_jrpc_client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tari-project/wallet_jrpc_client/-/wallet_jrpc_client-1.0.7.tgz",
+      "integrity": "sha512-HYsnZ+Im7wv/pFItwYz6AWv/DGL+iIzS/rdwzQi4PBXInilvCbPd3t0LEW5aEiHcdskTn8loM6DiSqG4ZzpikQ==",
       "dependencies": {
-        "@tariproject/typescript-bindings": "1.0.1"
+        "@tari-project/typescript-bindings": "1.0.3"
       }
     },
     "node_modules/@types/chrome": {
@@ -156,9 +155,9 @@
       "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA=="
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
+      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -356,9 +355,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
-      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
@@ -641,9 +640,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -679,9 +678,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@metamask/providers": "^9.0.0",
         "@tari-project/typescript-bindings": "^1.0.3",
-        "@tari-project/wallet_jrpc_client": "^1.0.7"
+        "@tari-project/wallet_jrpc_client": "^1.0.8"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -114,9 +114,9 @@
       "integrity": "sha512-CWJAxXgorgDXWO3U3gg/LOB3KoYgrq63zYwR1Z0tEZW0HkkA4BKlyHywRn/WpgvoCCAmAMOM6pO2jV5x1iqM/w=="
     },
     "node_modules/@tari-project/wallet_jrpc_client": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@tari-project/wallet_jrpc_client/-/wallet_jrpc_client-1.0.7.tgz",
-      "integrity": "sha512-HYsnZ+Im7wv/pFItwYz6AWv/DGL+iIzS/rdwzQi4PBXInilvCbPd3t0LEW5aEiHcdskTn8loM6DiSqG4ZzpikQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tari-project/wallet_jrpc_client/-/wallet_jrpc_client-1.0.8.tgz",
+      "integrity": "sha512-Dar8cIM7FzlbzOxch8QAuBQnSvaPlowBtDrGaswGl+F9SxGiDyQmQ0a8lHyQIhT58fY7XFYeip0miH6gzbDIWQ==",
       "dependencies": {
         "@tari-project/typescript-bindings": "1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/providers": "^9.0.0",
-    "@tari-project/wallet_jrpc_client": "^1.0.7",
+    "@tari-project/wallet_jrpc_client": "^1.0.8",
     "@tari-project/typescript-bindings": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/providers": "^9.0.0",
-    "@tariproject/wallet_jrpc_client": "https://gitpkg.now.sh/tari-project/tari-dan/clients/javascript/wallet_daemon_client?development&scripts.postinstall=npm%20run%20build",
-    "@tariproject/typescript-bindings": "https://gitpkg.now.sh/tari-project/tari-dan/bindings?development&scripts.postinstall=npm%20run%20tsc"
+    "@tariproject/wallet_jrpc_client": "^1.0.6",
+    "@tariproject/typescript-bindings": "^1.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "",
   "main": "./dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tariproject/tarijs",
+  "name": "@tari-project/tarijs",
   "version": "0.1.19",
   "description": "",
   "main": "./dist/index.js",
@@ -14,8 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/providers": "^9.0.0",
-    "@tariproject/wallet_jrpc_client": "^1.0.6",
-    "@tariproject/typescript-bindings": "^1.0.2"
+    "@tari-project/wallet_jrpc_client": "^1.0.7",
+    "@tari-project/typescript-bindings": "^1.0.3"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,5 +19,5 @@ export default {
     nodeResolve(),
     typescript(),
   ],
-  external: ["@tariproject/wallet_jrpc_client", "@metamask/providers"]
+  external: ["@tari-project/wallet_jrpc_client", "@metamask/providers"]
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,4 @@
-import type { SubstateType } from "@tariproject/typescript-bindings";
+import type { SubstateType } from "@tari-project/typescript-bindings";
 import {
   Account,
   SubmitTransactionRequest,

--- a/src/providers/metamask/index.ts
+++ b/src/providers/metamask/index.ts
@@ -11,7 +11,7 @@ import {MetaMaskInpageProvider} from '@metamask/providers';
 import {connectSnap, getSnap, isFlask, Snap} from "./utils";
 import {Maybe} from "@metamask/providers/dist/utils";
 import {Account} from "../types";
-import { SubstateType } from "@tariproject/typescript-bindings";
+import { SubstateType } from "@tari-project/typescript-bindings";
 
 export const MetamaskNotInstalled = 'METAMASK_NOT_INSTALLED';
 export const MetamaskIsNotFlask = 'METAMASK_IS_NOT_FLASK';

--- a/src/providers/tari_universe/provider.ts
+++ b/src/providers/tari_universe/provider.ts
@@ -17,7 +17,7 @@ import {
   WindowSize,
 } from "./types";
 import { TariProvider } from "../index";
-import { AccountsGetBalancesResponse, SubstateType } from "@tariproject/wallet_jrpc_client";
+import { AccountsGetBalancesResponse, SubstateType } from "@tari-project/wallet_jrpc_client";
 
 export class TariUniverseProvider implements TariProvider {
   public providerName = "TariUniverse";

--- a/src/providers/wallet_daemon/provider.ts
+++ b/src/providers/wallet_daemon/provider.ts
@@ -19,7 +19,7 @@ import {
     SubstateType,
     SubstatesListRequest,
     KeyBranch,
-} from "@tariproject/wallet_jrpc_client";
+} from "@tari-project/wallet_jrpc_client";
 import {WebRtcRpcTransport} from "./webrtc_transport";
 
 export const WalletDaemonNotConnected = 'WALLET_DAEMON_NOT_CONNECTED';

--- a/src/providers/wallet_daemon/webrtc.ts
+++ b/src/providers/wallet_daemon/webrtc.ts
@@ -1,5 +1,5 @@
 import {TariPermissions} from "./tari_permissions";
-import {transports} from "@tariproject/wallet_jrpc_client";
+import {transports} from "@tari-project/wallet_jrpc_client";
 
 class SignaligServer {
     private _token?: string;

--- a/src/providers/wallet_daemon/webrtc_transport.ts
+++ b/src/providers/wallet_daemon/webrtc_transport.ts
@@ -1,4 +1,4 @@
-import {transports} from "@tariproject/wallet_jrpc_client";
+import {transports} from "@tari-project/wallet_jrpc_client";
 import {TariConnection} from "./webrtc";
 
 export class WebRtcRpcTransport implements transports.RpcTransport {


### PR DESCRIPTION
Description
---
Added a new github CI action to automatically publish to npm registry on every version change

Motivation and Context
---
Tari.js is used by multiple projects. We want to automatically publish the latest version to the [NPM registry](https://www.npmjs.com/) when the package version increases. This way dependent projects can directly include the npm dependency for tari.js.

How Has This Been Tested?
---
In progress

What process can a PR reviewer use to test or verify this change?
---
Testing in progress

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
