### PR TITLE
fix: empty published npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/tarijs",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "@tari-project/tarijs",
   "version": "0.1.21",
   "description": "",
-  "main": "./src/index.js",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -b"
   },
@@ -22,6 +24,8 @@
     "typescript": "^5.0.4"
   },
   "files": [
-    "dist"
-  ]
+    "/dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "noEmit": true,
+    "module": "ES2020",
+    "target": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "./dist",
     "strictPropertyInitialization": false,
-  }
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strict": true,
+  },
+  "include": ["src/**/*"],
 }


### PR DESCRIPTION
Description
---
* Updates the `package.json` and `tsconfig.json` so the npm publish will include all required files
* Bumped the version to trigger a new npm publish

Motivation and Context
---
Currently, the tari.js npm package only contains the metadata and not the 

This PR updates the `package.json` and `tsconfig.json` so the npm publish will include all required files

How Has This Been Tested?
---
Does not apply

What process can a PR reviewer use to test or verify this change?
---
Does not apply

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
