### PR TITLE
chore(deps): bump typescript-bindings version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",
-        "@tari-project/typescript-bindings": "^1.0.3",
+        "@tari-project/typescript-bindings": "^1.0.6",
         "@tari-project/wallet_jrpc_client": "^1.0.8",
         "@walletconnect/modal": "^2.6.2",
         "@walletconnect/universal-provider": "^2.13.3"
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@tari-project/typescript-bindings": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tari-project/typescript-bindings/-/typescript-bindings-1.0.3.tgz",
-      "integrity": "sha512-CWJAxXgorgDXWO3U3gg/LOB3KoYgrq63zYwR1Z0tEZW0HkkA4BKlyHywRn/WpgvoCCAmAMOM6pO2jV5x1iqM/w=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tari-project/typescript-bindings/-/typescript-bindings-1.0.6.tgz",
+      "integrity": "sha512-dhik8u1vtJAzDvh0eSrdUjfgkevtunEBTqxV3KGgI8hCisihEteWY0frVk2z53Px2Kqy80UklBLiA2FliRMbOw=="
     },
     "node_modules/@tari-project/wallet_jrpc_client": {
       "version": "1.0.8",
@@ -593,6 +593,11 @@
       "dependencies": {
         "@tari-project/typescript-bindings": "1.0.3"
       }
+    },
+    "node_modules/@tari-project/wallet_jrpc_client/node_modules/@tari-project/typescript-bindings": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tari-project/typescript-bindings/-/typescript-bindings-1.0.3.tgz",
+      "integrity": "sha512-CWJAxXgorgDXWO3U3gg/LOB3KoYgrq63zYwR1Z0tEZW0HkkA4BKlyHywRn/WpgvoCCAmAMOM6pO2jV5x1iqM/w=="
     },
     "node_modules/@types/chrome": {
       "version": "0.0.136",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tari-project/tarijs",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "ISC",
       "dependencies": {
         "@metamask/providers": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@metamask/providers": "^9.0.0",
     "@tari-project/wallet_jrpc_client": "^1.0.8",
-    "@tari-project/typescript-bindings": "^1.0.3",
+    "@tari-project/typescript-bindings": "^1.0.6",
     "@walletconnect/modal": "^2.6.2",
     "@walletconnect/universal-provider": "^2.13.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Bundler",
     "declaration": true,
     "outDir": "./dist",
+    "rootDir": "./src",
     "strictPropertyInitialization": false,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Description
---
Bump dependency [typescript-bindings](https://github.com/tari-project/tari-dan/tree/development/bindings) to the newest version with fixed build.

Motivation and Context
---
This is a part of larger process of fixing build for all javascript/typescript packages (check this [PR](https://github.com/tari-project/tari-dan/pull/1115) in typescript-bindings repo).

How Has This Been Tested?
---
Changed locally tari.js dependency for tari universe and one of the tapplet. Both applications were working as expected with those changes.

What process can a PR reviewer use to test or verify this change?
---
Same as above.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
