### PR TITLE
fix(provider): extend tari universe provider types

### DIFF
--- a/packages/tari_provider/src/TariProvider.ts
+++ b/packages/tari_provider/src/TariProvider.ts
@@ -10,7 +10,6 @@ import {
   ListSubstatesResponse,
 } from "./types";
 
-
 export interface TariProvider {
   providerName: string;
   isConnected(): boolean;

--- a/packages/tari_provider/src/types.ts
+++ b/packages/tari_provider/src/types.ts
@@ -58,6 +58,8 @@ export interface VaultData {
   type: string;
   balance: number;
   resource_address: string;
+  token_symbol: string;
+  vault_id: string;
 }
 
 export interface VaultBalances {

--- a/packages/tari_universe/src/provider.ts
+++ b/packages/tari_universe/src/provider.ts
@@ -16,7 +16,6 @@ import {
   TariUniverseProviderParameters,
   WindowSize,
 } from "./types";
-import {} from "@tari-project/tari-provider";
 import { AccountsGetBalancesResponse, SubstateType } from "@tari-project/wallet_jrpc_client";
 import { sendProviderCall } from "./utils";
 

--- a/packages/tari_universe/src/provider.ts
+++ b/packages/tari_universe/src/provider.ts
@@ -7,7 +7,7 @@ import {
   ListSubstatesResponse,
   SubmitTransactionRequest,
   TariProvider,
-  TransactionResult
+  TransactionResult,
 } from "@tari-project/tari-provider";
 import {
   ProviderRequest,
@@ -16,7 +16,7 @@ import {
   TariUniverseProviderParameters,
   WindowSize,
 } from "./types";
-import {  } from "@tari-project/tari-provider";
+import {} from "@tari-project/tari-provider";
 import { AccountsGetBalancesResponse, SubstateType } from "@tari-project/wallet_jrpc_client";
 import { sendProviderCall } from "./utils";
 
@@ -84,21 +84,7 @@ export class TariUniverseProvider implements TariProvider {
   }
 
   public async getAccount(): Promise<Account> {
-    const { account_id, address, public_key } = await this.sendRequest({ methodName: "getAccount", args: [] });
-    const { balances } = await this.getAccountBalances(address);
-
-    return {
-      account_id,
-      address,
-      public_key,
-      resources: balances.map((b: any) => ({
-        type: b.resource_type,
-        resource_address: b.resource_address,
-        balance: b.balance + b.confidential_balance,
-        vault_id: "Vault" in b.vault_address ? b.vault_address.Vault : b.vault_address,
-        token_symbol: b.token_symbol,
-      })),
-    };
+    return this.sendRequest({ methodName: "getAccount", args: [] });
   }
 
   public async getAccountBalances(componentAddress: string): Promise<AccountsGetBalancesResponse> {


### PR DESCRIPTION
Description
---
This PR extends the `VauldData` type by `token_symbol` and `vault_id`. Also removes redundant code from the `TariUniverseProvider`. Additionally some cleanup.

Motivation and Context
---
Fix ts type errors while integrating the Ootle into the Tari Universe.

How Has This Been Tested?
---
Manually.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
