### PR TITLE
feat(cbor): add CBOR parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
           auto-install: true
       - run: pnpm install
       - run: moon :build
+      - run: moon :test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/tarijs/moon.yml
+++ b/packages/tarijs/moon.yml
@@ -54,6 +54,14 @@ tasks:
       - "@files(configs)"
       - "@files(tests)"
   test:
+    command: "pnpm run test"
+    inputs:
+      - "@files(sources)"
+      - "@files(tests)"
+      - "@files(configs)"
+    deps:
+      - "build"
+  integration-test:
     command: "pnpm run integration-tests"
     inputs:
       - "@files(sources)"

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "test": "vitest run src",
     "integration-tests": "vitest run integration-tests"
   },
   "keywords": [],

--- a/packages/tarijs/src/cbor.spec.ts
+++ b/packages/tarijs/src/cbor.spec.ts
@@ -1,0 +1,247 @@
+import { assert, describe, expect, it, vi } from "vitest";
+import { BinaryTag, CborValue, convertTaggedValue, getCborValueByPath, parseCbor } from "./cbor";
+
+describe("convertTaggedValue", () => {
+  it.each([
+    {
+      tag: BinaryTag.VaultId,
+      value: { Bytes: [1, 2, 3, 4, 255] },
+      expected: "vault_01020304ff",
+    },
+    {
+      tag: BinaryTag.ComponentAddress,
+      value: { Bytes: [1, 2, 3, 4, 255] },
+      expected: "component_01020304ff",
+    },
+    {
+      tag: BinaryTag.ResourceAddress,
+      value: { Bytes: [1, 2, 3, 4, 255] },
+      expected: "resource_01020304ff",
+    },
+  ])("converts tags with bytes into a string representation", ({ tag, value, expected }) => {
+    expect(convertTaggedValue(tag, value)).toEqual(expected);
+  });
+
+  it.each([
+    {
+      tag: BinaryTag.Metadata,
+      value: { Array: [{ Text: "One" }, { Text: "Two" }] },
+      expected: ["metadata", ["One", "Two"]],
+    },
+    {
+      tag: BinaryTag.Metadata,
+      value: {
+        Map: [
+          [{ Text: "key1" }, { Integer: 5 }],
+          [{ Text: "key2" }, { Integer: 3 }],
+        ],
+      },
+      expected: ["metadata", { key1: 5, key2: 3 }],
+    },
+  ])(
+    "converts other values into a tuple",
+    ({ tag, value, expected }: { tag: BinaryTag; value: unknown; expected: unknown }) => {
+      expect(convertTaggedValue(tag, value as CborValue)).toEqual(expected);
+    },
+  );
+
+  it("falls back to 'unknown' for unknown tags", () => {
+    expect(convertTaggedValue(55, { Bool: true })).toEqual(["unknown", true]);
+  });
+});
+
+describe("parseCbor", () => {
+  describe("Null", () => {
+    it("returns null", () => {
+      expect(parseCbor("Null")).toBeNull();
+    });
+  });
+
+  describe("Integer", () => {
+    it.each([
+      {
+        value: { Integer: 5 },
+        expected: 5,
+      },
+      {
+        value: { Integer: 3 },
+        expected: 3,
+      },
+    ])("returns an integer", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Float", () => {
+    it.each([
+      {
+        value: { Float: 3.9 },
+        expected: 3.9,
+      },
+      {
+        value: { Float: 3 },
+        expected: 3,
+      },
+    ])("returns a number", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Text", () => {
+    it.each([
+      {
+        value: { Text: "Some text" },
+        expected: "Some text",
+      },
+      {
+        value: { Text: "DEF" },
+        expected: "DEF",
+      },
+    ])("returns a string", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Bytes", () => {
+    it.each([
+      {
+        value: { Bytes: [1, 2, 0xff] },
+        expected: Uint8Array.from([1, 2, 0xff]),
+      },
+      {
+        value: { Bytes: [] },
+        expected: new Uint8Array(),
+      },
+    ])("returns Uint8Array", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Bool", () => {
+    it.each([
+      {
+        value: { Bool: true },
+        expected: true,
+      },
+      {
+        value: { Bool: false },
+        expected: false,
+      },
+    ])("returns a boolean", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Tag", () => {
+    it.each([
+      {
+        value: {
+          Tag: [BinaryTag.VaultId, { Bytes: [1, 2, 3, 4, 255] }],
+        },
+        expected: "vault_01020304ff",
+      },
+      {
+        value: { Tag: [BinaryTag.Metadata, { Array: [{ Text: "One" }, { Text: "Two" }] }] },
+        expected: ["metadata", ["One", "Two"]],
+      },
+    ])("returns a tag representation", ({ value, expected }: { value: unknown; expected: unknown }) => {
+      expect(parseCbor(value as CborValue)).toEqual(expected);
+    });
+  });
+
+  describe("Array", () => {
+    it.each([
+      {
+        value: {
+          Array: [{ Integer: 5 }, { Float: 3.9 }, { Text: "Some text" }, { Bytes: [1, 2, 0xff] }, { Bool: true }],
+        },
+        expected: [5, 3.9, "Some text", Uint8Array.from([1, 2, 0xff]), true],
+      },
+    ])("returns an array", ({ value, expected }) => {
+      expect(parseCbor(value)).toEqual(expected);
+    });
+  });
+
+  describe("Map", () => {
+    it.each([
+      {
+        value: {
+          Map: [
+            [{ Text: "key1" }, { Integer: 5 }],
+            [{ Text: "key2" }, { Float: 3.9 }],
+            [{ Text: "key3" }, { Text: "Some text" }],
+            [{ Text: "key4" }, { Bytes: [1, 2, 0xff] }],
+            [{ Text: "key5" }, { Bool: true }],
+            [{ Text: "key6" }, { Array: [{ Integer: 1 }, { Integer: 2 }] }],
+            [
+              { Text: "key_nested" },
+              {
+                Map: [
+                  [{ Text: "nested1" }, { Text: "Nested text" }],
+                  [{ Text: "nested2" }, { Integer: 2 }],
+                ],
+              },
+            ],
+          ],
+        },
+        expected: {
+          key1: 5,
+          key2: 3.9,
+          key3: "Some text",
+          key4: Uint8Array.from([1, 2, 0xff]),
+          key5: true,
+          key6: [1, 2],
+          key_nested: {
+            nested1: "Nested text",
+            nested2: 2,
+          },
+        },
+      },
+    ])("returns an object", ({ value, expected }: { value: unknown; expected: unknown }) => {
+      expect(parseCbor(value as CborValue)).toEqual(expected);
+    });
+  });
+});
+
+describe("getCborValueByPath", () => {
+  it.each([
+    {
+      path: "$.key1",
+      expected: 5,
+    },
+    {
+      path: "$.key3",
+      expected: "Some text",
+    },
+    {
+      path: "$.key6.1",
+      expected: 2,
+    },
+    {
+      path: "$.key_nested.nested1",
+      expected: "Nested text",
+    },
+  ])("gets value by path", ({ path, expected }) => {
+    const cbor: CborValue = {
+      Map: [
+        [{ Text: "key1" }, { Integer: 5 }],
+        [{ Text: "key2" }, { Float: 3.9 }],
+        [{ Text: "key3" }, { Text: "Some text" }],
+        [{ Text: "key4" }, { Bytes: [1, 2, 0xff] }],
+        [{ Text: "key5" }, { Bool: true }],
+        [{ Text: "key6" }, { Array: [{ Integer: 1 }, { Integer: 2 }] }],
+        [
+          { Text: "key_nested" },
+          {
+            Map: [
+              [{ Text: "nested1" }, { Text: "Nested text" }],
+              [{ Text: "nested2" }, { Integer: 2 }],
+            ],
+          },
+        ],
+      ],
+    };
+
+    expect(getCborValueByPath(cbor, path)).toEqual(expected);
+  });
+});

--- a/packages/tarijs/src/cbor.spec.ts
+++ b/packages/tarijs/src/cbor.spec.ts
@@ -201,6 +201,10 @@ describe("parseCbor", () => {
       expect(parseCbor(value as CborValue)).toEqual(expected);
     });
   });
+  
+  it.each([{}, { Unknown: 2 }])("throws, when data in unknown format is found", (value: unknown) => {
+    expect(() => parseCbor(value as CborValue)).toThrow();
+  });
 });
 
 describe("getCborValueByPath", () => {
@@ -220,6 +224,14 @@ describe("getCborValueByPath", () => {
     {
       path: "$.key_nested.nested1",
       expected: "Nested text",
+    },
+    {
+      path: "$.missing.path",
+      expected: null,
+    },
+    {
+      path: "$.key6.999",
+      expected: null,
     },
   ])("gets value by path", ({ path, expected }) => {
     const cbor: CborValue = {

--- a/packages/tarijs/src/cbor.ts
+++ b/packages/tarijs/src/cbor.ts
@@ -1,0 +1,110 @@
+export type CborValue =
+  | { Map: Array<[CborValue, CborValue]> }
+  | { Array: CborValue[] }
+  | { Tag: [BinaryTag, CborValue] }
+  | { Bool: boolean }
+  | { Bytes: number[] }
+  | { Text: string }
+  | { Float: number }
+  | { Integer: number }
+  | "Null";
+
+export function parseCbor(value: CborValue): unknown {
+  if (typeof value === "string") {
+    if (value === "Null") {
+      return null;
+    }
+    throw new Error("Unknown CBOR value type");
+  }
+  if ("Map" in value) {
+    return Object.fromEntries(value.Map.map(([k, v]) => [parseCbor(k), parseCbor(v)]));
+  } else if ("Array" in value) {
+    return value.Array.map(parseCbor);
+  } else if ("Tag" in value) {
+    const [type, data] = value.Tag;
+    return convertTaggedValue(type, data);
+  } else if ("Bool" in value) {
+    return value.Bool;
+  } else if ("Bytes" in value) {
+    return new Uint8Array(value.Bytes);
+  } else if ("Text" in value) {
+    return value.Text;
+  } else if ("Float" in value) {
+    return value.Float;
+  } else if ("Integer" in value) {
+    return value.Integer;
+  }
+  throw new Error("Unknown CBOR value type");
+}
+
+export function getCborValueByPath(cborRepr: CborValue | null, path: string): unknown {
+  if (!cborRepr) {
+    return null;
+  }
+  let value = cborRepr;
+  for (const part of path.split(".")) {
+    if (part == "$") {
+      continue;
+    }
+    if (typeof value !== "object") {
+      return null;
+    }
+    if ("Map" in value) {
+      const mapEntry = value.Map.find((v) => parseCbor(v[0]) === part)?.[1];
+      if (mapEntry) {
+        value = mapEntry;
+        continue;
+      } else {
+        return null;
+      }
+    }
+
+    if ("Array" in value) {
+      value = value.Array[parseInt(part)];
+      continue;
+    }
+
+    return null;
+  }
+  return parseCbor(value);
+}
+
+function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export enum BinaryTag {
+  ComponentAddress = 128,
+  Metadata = 129,
+  NonFungibleAddress = 130,
+  ResourceAddress = 131,
+  VaultId = 132,
+  BucketId = 133,
+  TransactionReceipt = 134,
+  ProofId = 135,
+  UnclaimedConfidentialOutputAddress = 136,
+  TemplateAddress = 137,
+  ValidatorNodeFeePool = 138,
+}
+
+const BINARY_TAG_KEYS = new Map<BinaryTag, string>([
+  [BinaryTag.ComponentAddress, "component"],
+  [BinaryTag.Metadata, "metadata"],
+  [BinaryTag.NonFungibleAddress, "nft"],
+  [BinaryTag.ResourceAddress, "resource"],
+  [BinaryTag.VaultId, "vault"],
+  [BinaryTag.BucketId, "bucket"],
+  [BinaryTag.TransactionReceipt, "transaction-receipt"],
+  [BinaryTag.ProofId, "proof"],
+  [BinaryTag.UnclaimedConfidentialOutputAddress, "unclaimed-confidential-output-address"],
+  [BinaryTag.TemplateAddress, "template-address"],
+  [BinaryTag.ValidatorNodeFeePool, "validator-node-fee-pool"],
+]);
+
+export function convertTaggedValue(type: number, value: CborValue): string | unknown {
+  const tag = BINARY_TAG_KEYS.get(type) ?? "unknown";
+  const decoded = parseCbor(value);
+  return decoded instanceof Uint8Array ? `${tag}_${uint8ArrayToHex(decoded)}` : [tag, decoded];
+}

--- a/packages/tarijs/src/cbor.ts
+++ b/packages/tarijs/src/cbor.ts
@@ -60,8 +60,12 @@ export function getCborValueByPath(cborRepr: CborValue | null, path: string): un
     }
 
     if ("Array" in value) {
-      value = value.Array[parseInt(part)];
-      continue;
+      const arr = value.Array;
+      const index = parseInt(part);
+      if (!Number.isNaN(index) && Array.isArray(arr) && arr.length > index) {
+        value = arr[index];
+        continue;
+      }
     }
 
     return null;

--- a/packages/tarijs/src/index.ts
+++ b/packages/tarijs/src/index.ts
@@ -33,6 +33,7 @@ import {
   toWorkspace,
 } from "@tari-project/tarijs-builders";
 import * as templates from "./templates";
+import { parseCbor, getCborValueByPath } from "./cbor";
 
 export * from "@tari-project/tarijs-types";
 export {
@@ -66,4 +67,6 @@ export {
   fromWorkspace,
   toWorkspace,
   templates,
+  parseCbor,
+  getCborValueByPath,
 };


### PR DESCRIPTION
Description
---

Adds two CBOR parsing related functions:
- `parseCbor`
- `getCborValueByPath`

Motivation and Context
---

Many applications will get substates and will need to parse the contents.
Since they are encoded as JSON representation of CBOR, we need a common way to parse them.

How Has This Been Tested?
---

The PR has unit tests. They will be run as part of CI pipeline

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
