### PR TITLE
feat(tx): get component from tx result

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-builders",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/builders/src/helpers/submitTransaction.ts
+++ b/packages/builders/src/helpers/submitTransaction.ts
@@ -6,12 +6,12 @@ import {
   TransactionStatus,
   DownSubstates,
   UpSubstates,
-  FinalizeResultStatus,
-  TxResultAccept,
   SubmitTxResult,
   ReqSubstate,
   SubmitTransactionRequest,
+  ComponentAddress,
 } from "@tari-project/tarijs-types";
+import { getSubstateValueFromUpSubstates, substateIdToString, txResultCheck } from "@tari-project/tarijs-types";
 
 export function buildTransactionRequest(
   transaction: Transaction,
@@ -46,10 +46,28 @@ export async function submitAndWaitForTransaction(
   try {
     const response = await signer.submitTransaction(req);
     const result = await waitForTransactionResult(signer, response.transaction_id);
+    const { upSubstates, downSubstates } = getAcceptResultSubstates(result);
+    const newComponents = getSubstateValueFromUpSubstates("Component", upSubstates);
+    function getComponentForTemplate(templateAddress: string): ComponentAddress | null {
+      const templateAddressBytes = new TextEncoder().encode(templateAddress);
+      for (const [substateId, substate] of upSubstates) {
+        if ("Component" in substate.substate) {
+          const componentHeader = substate.substate.Component;
+          if (componentHeader.template_address === templateAddressBytes) {
+            return substateIdToString(substateId);
+          }
+        }
+      }
+      return null;
+    }
 
     return {
       response,
       result,
+      upSubstates,
+      downSubstates,
+      newComponents,
+      getComponentForTemplate,
     };
   } catch (e) {
     throw new Error(`Transaction failed: ${e}`);
@@ -81,17 +99,14 @@ export async function waitForTransactionResult(
   }
 }
 
-export function getAcceptResultSubstates(
-  txResult: TransactionResult,
-): { upSubstates: UpSubstates; downSubstates: DownSubstates } | undefined {
+export function getAcceptResultSubstates(txResult: TransactionResult): {
+  upSubstates: UpSubstates;
+  downSubstates: DownSubstates;
+} {
   const result = txResult.result?.result;
 
-  if (result && isAccept(result)) {
+  if (result && txResultCheck.isAccept(result)) {
     return { upSubstates: result.Accept.up_substates, downSubstates: result.Accept.down_substates };
   }
-  return undefined;
-}
-
-function isAccept(result: FinalizeResultStatus): result is TxResultAccept {
-  return "Accept" in result;
+  return { upSubstates: [], downSubstates: [] };
 }

--- a/packages/builders/src/helpers/submitTransaction.ts
+++ b/packages/builders/src/helpers/submitTransaction.ts
@@ -44,10 +44,16 @@ export async function submitAndWaitForTransaction(
   req: SubmitTransactionRequest,
 ): Promise<SubmitTxResult> {
   try {
+    console.warn("🌟🌟🌟 [tarijs][submitAndWait] signer, req", signer, req);
     const response = await signer.submitTransaction(req);
+    console.warn("🌟🌟🌟 [tarijs][submitAndWait] response", response);
     const result = await waitForTransactionResult(signer, response.transaction_id);
+    console.warn("🌟🌟🌟 [tarijs][submitAndWait] tx result", result);
     const { upSubstates, downSubstates } = getAcceptResultSubstates(result);
+    console.warn("🌟🌟🌟 [tarijs][submitAndWait] substates", upSubstates, downSubstates);
     const newComponents = getSubstateValueFromUpSubstates("Component", upSubstates);
+    console.warn("🌟🌟🌟 [tarijs][submitAndWait] components", newComponents);
+
     function getComponentForTemplate(templateAddress: string): ComponentAddress | null {
       const templateAddressBytes = new TextEncoder().encode(templateAddress);
       for (const [substateId, substate] of upSubstates) {
@@ -105,6 +111,12 @@ export function getAcceptResultSubstates(txResult: TransactionResult): {
 } {
   const result = txResult.result?.result;
 
+  if (result && txResultCheck.isAcceptFeeRejectRest(result)) {
+    return {
+      upSubstates: result.AcceptFeeRejectRest[0].up_substates,
+      downSubstates: result.AcceptFeeRejectRest[0].down_substates,
+    };
+  }
   if (result && txResultCheck.isAccept(result)) {
     return { upSubstates: result.Accept.up_substates, downSubstates: result.Accept.down_substates };
   }

--- a/packages/builders/src/helpers/submitTransaction.ts
+++ b/packages/builders/src/helpers/submitTransaction.ts
@@ -52,8 +52,10 @@ export async function submitAndWaitForTransaction(
     function getComponentForTemplate(templateAddress: string): ComponentAddress | null {
       for (const [substateId, substate] of upSubstates) {
         if ("Component" in substate.substate) {
-          const componentTemplate = substate.substate.Component.template_address as any;
-          if (templateAddress === componentTemplate) {
+          const templateAddr = substate.substate.Component.template_address;
+          const templateString =
+            typeof templateAddr === "string" ? templateAddr : new TextDecoder().decode(templateAddr);
+          if (templateAddress === templateString) {
             return substateIdToString(substateId);
           }
         }

--- a/packages/builders/src/helpers/submitTransaction.ts
+++ b/packages/builders/src/helpers/submitTransaction.ts
@@ -44,22 +44,16 @@ export async function submitAndWaitForTransaction(
   req: SubmitTransactionRequest,
 ): Promise<SubmitTxResult> {
   try {
-    console.warn("🌟🌟🌟 [tarijs][submitAndWait] signer, req", signer, req);
     const response = await signer.submitTransaction(req);
-    console.warn("🌟🌟🌟 [tarijs][submitAndWait] response", response);
     const result = await waitForTransactionResult(signer, response.transaction_id);
-    console.warn("🌟🌟🌟 [tarijs][submitAndWait] tx result", result);
     const { upSubstates, downSubstates } = getAcceptResultSubstates(result);
-    console.warn("🌟🌟🌟 [tarijs][submitAndWait] substates", upSubstates, downSubstates);
     const newComponents = getSubstateValueFromUpSubstates("Component", upSubstates);
-    console.warn("🌟🌟🌟 [tarijs][submitAndWait] components", newComponents);
 
     function getComponentForTemplate(templateAddress: string): ComponentAddress | null {
-      const templateAddressBytes = new TextEncoder().encode(templateAddress);
       for (const [substateId, substate] of upSubstates) {
         if ("Component" in substate.substate) {
-          const componentHeader = substate.substate.Component;
-          if (componentHeader.template_address === templateAddressBytes) {
+          const componentTemplate = substate.substate.Component.template_address as any;
+          if (templateAddress === componentTemplate) {
             return substateIdToString(substateId);
           }
         }

--- a/packages/tari_universe/package.json
+++ b/packages/tari_universe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-universe-signer",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_universe/src/signer.ts
+++ b/packages/tari_universe/src/signer.ts
@@ -75,7 +75,7 @@ export class TariUniverseSigner implements TariSigner {
     });
   }
 
-  public async createFreeTestCoins(): Promise<void> {
+  public async createFreeTestCoins(): Promise<AccountData> {
     return this.sendRequest({ methodName: "createFreeTestCoins", args: [] });
   }
 

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-all",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/package.json
+++ b/packages/tarijs_types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-types",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/src/TransactionResult.ts
+++ b/packages/tarijs_types/src/TransactionResult.ts
@@ -1,5 +1,7 @@
 import { TransactionStatus } from "./TransactionStatus";
 import { FinalizeResult } from "./FinalizeResult";
+import { DownSubstates, UpSubstates } from "./SubstateDiff";
+import { ComponentAddress } from "@tari-project/typescript-bindings";
 
 export type SubmitTransactionResponse = {
   transaction_id: string;
@@ -8,9 +10,19 @@ export type SubmitTransactionResponse = {
 export interface SubmitTxResult {
   response: SubmitTransactionResponse;
   result: TransactionResult;
+  upSubstates: UpSubstates;
+  downSubstates: DownSubstates;
+  newComponents: UpSubstates;
+  getComponentForTemplate(templateAddress: string): ComponentAddress | null;
 }
 
 export type TransactionResult = {
+  transaction_id: string;
+  status: TransactionStatus;
+  result: FinalizeResult | null;
+};
+
+export type TransactionResultResponse = {
   transaction_id: string;
   status: TransactionStatus;
   result: FinalizeResult | null;

--- a/packages/tarijs_types/src/helpers/index.ts
+++ b/packages/tarijs_types/src/helpers/index.ts
@@ -1,6 +1,7 @@
 import { NonFungibleId, NonFungibleToken, ResourceAddress } from "@tari-project/typescript-bindings";
 import { TransactionStatus } from "../TransactionStatus";
 export { fromHexString, toHexString } from "./hexString";
+export { txResultCheck, getSubstateValueFromUpSubstates, getComponentsForTemplate } from "./txResult";
 export { BinaryTag, CborValue, convertTaggedValue, getCborValueByPath, parseCbor } from "./cbor";
 export {
   substateIdToString,

--- a/packages/tarijs_types/src/helpers/txResult.ts
+++ b/packages/tarijs_types/src/helpers/txResult.ts
@@ -1,0 +1,75 @@
+import {
+  SubstateDiff,
+  VaultId,
+  Vault,
+  SubstateId,
+  SubstateValue,
+  ResourceContainer,
+  ResourceAddress,
+  Amount,
+  RejectReason,
+  substateIdToString,
+  ComponentAddress,
+} from "@tari-project/typescript-bindings";
+import { FinalizeResultStatus } from "../FinalizeResult";
+import { UpSubstates } from "../SubstateDiff";
+
+function isOfType<T extends object>(obj: T, key: keyof T): boolean {
+  return obj !== null && typeof obj === "object" && key in obj;
+}
+
+export const txResultCheck = {
+  isAccept: (result: FinalizeResultStatus): result is { Accept: SubstateDiff } => {
+    return "Accept" in result;
+  },
+
+  isVaultId: (substateId: SubstateId): substateId is { Vault: VaultId } => {
+    return isOfType(substateId, "Vault" as keyof SubstateId);
+  },
+
+  isVaultSubstate: (substate: SubstateValue): substate is { Vault: Vault } => {
+    return "Vault" in substate;
+  },
+
+  isFungible: (
+    resourceContainer: ResourceContainer,
+  ): resourceContainer is { Fungible: { address: ResourceAddress; amount: Amount; locked_amount: Amount } } => {
+    return "Fungible" in resourceContainer;
+  },
+
+  isReject: (result: FinalizeResultStatus): result is { Reject: RejectReason } => {
+    return "Reject" in result;
+  },
+  isAcceptFeeRejectRest: (
+    result: FinalizeResultStatus,
+  ): result is { AcceptFeeRejectRest: [SubstateDiff, RejectReason] } => {
+    return "AcceptFeeRejectRest" in result;
+  },
+};
+
+export function getSubstateValueFromUpSubstates(
+  substateType: keyof SubstateValue | string,
+  upSubstates: UpSubstates,
+): UpSubstates {
+  const components: UpSubstates = [];
+  for (const [substateId, substate] of upSubstates) {
+    if (substateType in substate.substate) {
+      components.push([substateId, substate]);
+    }
+  }
+  return components;
+}
+
+export function getComponentsForTemplate(templateAddress: string, upSubstates: UpSubstates): ComponentAddress[] | null {
+  const components: ComponentAddress[] = [];
+  const templateAddressBytes = new TextEncoder().encode(templateAddress);
+  for (const [substateId, substate] of upSubstates) {
+    if ("Component" in substate.substate) {
+      const componentHeader = substate.substate.Component;
+      if (componentHeader.template_address === templateAddressBytes) {
+        components.push(substateIdToString(substateId));
+      }
+    }
+  }
+  return components;
+}

--- a/packages/tarijs_types/src/index.ts
+++ b/packages/tarijs_types/src/index.ts
@@ -16,7 +16,12 @@ export { Instruction } from "./Instruction";
 export { Transaction } from "./Transaction";
 export { SubstateDiff, DownSubstates, UpSubstates } from "./SubstateDiff";
 export { SubstateRequirement } from "./SubstateRequirement";
-export { TransactionResult, SubmitTxResult, SubmitTransactionResponse } from "./TransactionResult";
+export {
+  TransactionResult,
+  SubmitTxResult,
+  SubmitTransactionResponse,
+  TransactionResultResponse,
+} from "./TransactionResult";
 export { TransactionSignature } from "./TransactionSignature";
 export { TransactionStatus } from "./TransactionStatus";
 export { UnsignedTransaction } from "./UnsignedTransaction";
@@ -57,6 +62,9 @@ export {
   convertTaggedValue,
   getCborValueByPath,
   parseCbor,
+  getSubstateValueFromUpSubstates,
+  getComponentsForTemplate,
+  txResultCheck,
   BinaryTag,
   CborValue,
 } from "./helpers";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,11 @@ catalogs:
       specifier: ^18.2.0
       version: 18.3.1
     '@tari-project/typescript-bindings':
-      specifier: ^1.5.1
-      version: 1.5.1
+      specifier: ^1.5.2
+      version: 1.5.2
     '@tari-project/wallet_jrpc_client':
-      specifier: ^1.5.1
-      version: 1.5.1
+      specifier: ^1.5.2
+      version: 1.5.2
     '@types/node':
       specifier: ^22.13.1
       version: 22.13.1
@@ -117,10 +117,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -142,7 +142,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -167,7 +167,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -183,7 +183,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -205,10 +205,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -248,7 +248,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
       '@tari-project/wallet-connect-signer':
         specifier: workspace:^
         version: link:../walletconnect
@@ -273,7 +273,7 @@ importers:
     dependencies:
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -295,7 +295,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -317,10 +317,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.1
+        version: 1.5.2
       '@walletconnect/modal':
         specifier: 'catalog:'
         version: 2.7.0(@types/react@19.0.10)(react@19.0.0)
@@ -2045,11 +2045,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tari-project/typescript-bindings@1.5.1':
-    resolution: {integrity: sha512-WRmkF0aAOaPQt9orouATYBCHqvx7m0zsOfqZi2PzriWWwyLNH0jHKKzFGJbcV1NWr8q87kA7v4e1+rY004HWMg==}
+  '@tari-project/typescript-bindings@1.5.2':
+    resolution: {integrity: sha512-Dyi2CvX9eEKvLHTx5Rt/EE9/atuZRfR4/OR2gSOjyjzKPqGxMzaKczg0aD1SvrLrjwTK4Axz4pM5lFqY+HPvaQ==}
 
-  '@tari-project/wallet_jrpc_client@1.5.1':
-    resolution: {integrity: sha512-nVVMMVL2DodXM9O6BwV8hdsyBcBK3Ww0D1WJ11WEZxMzzcu4AOVYbKzxOLVegHY/chiY3h6s1zTNcH0McA7DXw==}
+  '@tari-project/wallet_jrpc_client@1.5.2':
+    resolution: {integrity: sha512-bOxWbLTa3C4UfNcU6wkWBETl0KQ2C4/cMNXCoTaPR8ehDtNmMeralas/c0KBjkKos+qMu5W/VubNp6Aw+9japw==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -8868,11 +8868,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tari-project/typescript-bindings@1.5.1': {}
+  '@tari-project/typescript-bindings@1.5.2': {}
 
-  '@tari-project/wallet_jrpc_client@1.5.1':
+  '@tari-project/wallet_jrpc_client@1.5.2':
     dependencies:
-      '@tari-project/typescript-bindings': 1.5.1
+      '@tari-project/typescript-bindings': 1.5.2
 
   '@trysound/sax@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ catalog:
   vitest: ^3.0.4
   vite: ^6.1.0
   "@types/node": ^22.13.1
-  "@tari-project/typescript-bindings": ^1.5.1
-  "@tari-project/wallet_jrpc_client": ^1.5.1
+  "@tari-project/typescript-bindings": ^1.5.2
+  "@tari-project/wallet_jrpc_client": ^1.5.2
   "@metamask/providers": ^18.2.0
   "@walletconnect/universal-provider": ^2.13.3
   "@walletconnect/modal": ^2.6.2


### PR DESCRIPTION
Description
---
Extend `SubmitTxResult` type and `submitAndWaitForTransaction` to easily find new component created out of template.

```
const { response, result, downSubstates, upSubstates, newComponents } =
    await submitAndWaitForTransaction(provider, req);
```

It is also possible to check if any component was created from the `template_address`:
```
  const submitTxResult = await submitAndWaitForTransaction(provider, req);

  const { response, result, downSubstates, upSubstates, newComponents } =
    submitTxResult;
  
    const component = submitTxResult.getComponentForTemplate(COIN_TEMPLATE);
```


Motivation and Context
---
It's hard to find the component address out of the transaction result, based on the template address.

How Has This Been Tested?
---
Manually


![image](https://github.com/user-attachments/assets/c6afd104-2aac-495b-aa93-3bc64c629d91)

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction processing with improved retrieval of component information and consistent result outputs.
  - Updated test coin functionality now returns account details.
  - Expanded transaction responses with additional properties and new helper utilities.

- **Chores**
  - Upgraded package versions (0.5.3 → 0.5.4) across multiple packages.
  - Updated dependency versions for key integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->