### PR TITLE
feat(tx): add dry run

### DIFF
--- a/packages/indexer_provider/src/provider.ts
+++ b/packages/indexer_provider/src/provider.ts
@@ -70,7 +70,7 @@ export class IndexerProvider implements TariProvider {
 
   public async getSubstate({ substate_address, version }: GetSubstateRequest): Promise<Substate> {
     const resp = await this.client.getSubstate({
-      address: stringToSubstateId(substate_address),
+      address: substate_address,
       version: version ?? null,
       local_search_only: false,
     });

--- a/packages/tari_universe/src/signer.ts
+++ b/packages/tari_universe/src/signer.ts
@@ -11,14 +11,14 @@ import {
   ListAccountNftFromBalancesRequest,
 } from "@tari-project/tarijs-types";
 import { SignerRequest, SignerMethodNames, SignerReturnType, TariUniverseSignerParameters, WindowSize } from "./types";
+import { sendSignerCall } from "./utils";
+import { TariSigner } from "@tari-project/tari-signer";
 import {
   AccountsGetBalancesResponse,
   ConfidentialViewVaultBalanceRequest,
   ListAccountNftRequest,
   ListAccountNftResponse,
-} from "@tari-project/wallet_jrpc_client";
-import { sendSignerCall } from "./utils";
-import { TariSigner } from "@tari-project/tari-signer";
+} from "@tari-project/typescript-bindings";
 
 export class TariUniverseSigner implements TariSigner {
   public signerName = "TariUniverse";

--- a/packages/wallet_daemon/package.json
+++ b/packages/wallet_daemon/package.json
@@ -16,6 +16,7 @@
     "@tari-project/tari-permissions": "workspace:^",
     "@tari-project/tari-signer": "workspace:^",
     "@tari-project/tarijs-types": "workspace:^",
+    "@tari-project/typescript-bindings": "catalog:",
     "@tari-project/wallet_jrpc_client": "catalog:"
   },
   "devDependencies": {

--- a/packages/wallet_daemon/src/signer.ts
+++ b/packages/wallet_daemon/src/signer.ts
@@ -1,17 +1,7 @@
 import { TariPermissions } from "@tari-project/tari-permissions";
 import { TariConnection } from "./webrtc";
 import { TariSigner } from "@tari-project/tari-signer";
-import {
-  WalletDaemonClient,
-  substateIdToString,
-  Instruction,
-  SubstatesListRequest,
-  KeyBranch,
-  SubstateId,
-  ListAccountNftRequest,
-  ListAccountNftResponse,
-  ConfidentialViewVaultBalanceRequest,
-} from "@tari-project/wallet_jrpc_client";
+import { WalletDaemonClient } from "@tari-project/wallet_jrpc_client";
 import { WebRtcRpcTransport } from "./webrtc_transport";
 import {
   AccountData,
@@ -25,6 +15,16 @@ import {
   ListSubstatesResponse,
   ListSubstatesRequest,
 } from "@tari-project/tarijs-types";
+import {
+  ConfidentialViewVaultBalanceRequest,
+  Instruction,
+  KeyBranch,
+  ListAccountNftRequest,
+  ListAccountNftResponse,
+  SubstateId,
+  substateIdToString,
+  SubstatesListRequest,
+} from "@tari-project/typescript-bindings";
 
 export const WalletDaemonNotConnected = "WALLET_DAEMON_NOT_CONNECTED";
 export const Unsupported = "UNSUPPORTED";
@@ -194,7 +194,9 @@ export class WalletDaemonTariSigner implements TariSigner {
       detect_inputs_use_unversioned: req.detect_inputs_use_unversioned,
     };
 
-    const res = await this.client.submitTransaction(params);
+    const res = req.is_dry_run
+      ? await this.client.submitTransactionDryRun(params)
+      : await this.client.submitTransaction(params);
     return { transaction_id: res.transaction_id };
   }
 

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -2,15 +2,6 @@ import { TariSigner } from "@tari-project/tari-signer";
 import UniversalProvider from "@walletconnect/universal-provider";
 import { WalletConnectModal } from "@walletconnect/modal";
 import {
-  ConfidentialViewVaultBalanceRequest,
-  Instruction,
-  KeyBranch,
-  ListAccountNftRequest,
-  ListAccountNftResponse,
-  substateIdToString,
-  TransactionSubmitRequest,
-} from "@tari-project/wallet_jrpc_client";
-import {
   convertStringToTransactionStatus,
   GetTransactionResultResponse,
   SubmitTransactionRequest,
@@ -22,6 +13,15 @@ import {
   ListSubstatesResponse,
   ListSubstatesRequest,
 } from "@tari-project/tarijs-types";
+import {
+  ConfidentialViewVaultBalanceRequest,
+  Instruction,
+  KeyBranch,
+  ListAccountNftRequest,
+  ListAccountNftResponse,
+  substateIdToString,
+  TransactionSubmitRequest,
+} from "@tari-project/typescript-bindings";
 
 const walletConnectParams = {
   requiredNamespaces: {

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -193,7 +193,7 @@ export class WalletConnectTariSigner implements TariSigner {
   }
 
   async submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse> {
-    const method = "tari_submitTransaction";
+    const method = req.is_dry_run ? "tari_submitTransactionDryRun" : "tari_submitTransaction";
     const params: TransactionSubmitRequest = {
       transaction: {
         V1: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,11 @@ catalogs:
       specifier: ^18.2.0
       version: 18.3.1
     '@tari-project/typescript-bindings':
-      specifier: ^1.5.2
-      version: 1.5.2
+      specifier: ^1.5.5
+      version: 1.5.5
     '@tari-project/wallet_jrpc_client':
-      specifier: ^1.5.2
-      version: 1.5.2
+      specifier: ^1.5.4
+      version: 1.5.4
     '@types/node':
       specifier: ^22.13.1
       version: 22.13.1
@@ -117,10 +117,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.4
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -142,7 +142,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -167,7 +167,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -183,7 +183,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -205,10 +205,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.4
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -248,7 +248,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
       '@tari-project/wallet-connect-signer':
         specifier: workspace:^
         version: link:../walletconnect
@@ -273,7 +273,7 @@ importers:
     dependencies:
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -293,9 +293,12 @@ importers:
       '@tari-project/tarijs-types':
         specifier: workspace:^
         version: link:../tarijs_types
+      '@tari-project/typescript-bindings':
+        specifier: 'catalog:'
+        version: 1.5.5
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.4
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -317,10 +320,10 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.5
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.5.2
+        version: 1.5.4
       '@walletconnect/modal':
         specifier: 'catalog:'
         version: 2.7.0(@types/react@19.0.10)(react@19.0.0)
@@ -2045,11 +2048,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tari-project/typescript-bindings@1.5.2':
-    resolution: {integrity: sha512-Dyi2CvX9eEKvLHTx5Rt/EE9/atuZRfR4/OR2gSOjyjzKPqGxMzaKczg0aD1SvrLrjwTK4Axz4pM5lFqY+HPvaQ==}
+  '@tari-project/typescript-bindings@1.5.5':
+    resolution: {integrity: sha512-ssWxu+QR4y3RH449IeEQFu/3VVbogqYRL3hJQHISewv+EZLUbdwdGyGAiBe7wWMbzl43aVjln9/df00XpbOWhA==}
 
-  '@tari-project/wallet_jrpc_client@1.5.2':
-    resolution: {integrity: sha512-bOxWbLTa3C4UfNcU6wkWBETl0KQ2C4/cMNXCoTaPR8ehDtNmMeralas/c0KBjkKos+qMu5W/VubNp6Aw+9japw==}
+  '@tari-project/wallet_jrpc_client@1.5.4':
+    resolution: {integrity: sha512-NHTC+QVhe+sOkdGM0K2pq7K3ororXZD6IZnbe9nHZobneS8ZFx3Qynm6vHpk5csXaUjlwEImwszZiXtBboJ6zg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -8868,11 +8871,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tari-project/typescript-bindings@1.5.2': {}
+  '@tari-project/typescript-bindings@1.5.5': {}
 
-  '@tari-project/wallet_jrpc_client@1.5.2':
+  '@tari-project/wallet_jrpc_client@1.5.4':
     dependencies:
-      '@tari-project/typescript-bindings': 1.5.2
+      '@tari-project/typescript-bindings': 1.5.5
 
   '@trysound/sax@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ catalog:
   vitest: ^3.0.4
   vite: ^6.1.0
   "@types/node": ^22.13.1
-  "@tari-project/typescript-bindings": ^1.5.2
-  "@tari-project/wallet_jrpc_client": ^1.5.2
+  "@tari-project/typescript-bindings": ^1.5.5
+  "@tari-project/wallet_jrpc_client": ^1.5.4
   "@metamask/providers": ^18.2.0
   "@walletconnect/universal-provider": ^2.13.3
   "@walletconnect/modal": ^2.6.2


### PR DESCRIPTION
Description
---

Adds support for `dry_run`.

Motivation and Context
---

`SubmitTransactionRequest` had aloready `is_dry_run` paramer, but it was not used, when submitting the transaction.

How Has This Been Tested?
---

Added an integration test, which ran successfully.

What process can a PR reviewer use to test or verify this change?
---

```sh
$ cd paclages/tarijs
$ WALLET_DAEMON_JSON_RPC_URL=http://127.0.0.1:12010/json_rpc pn run integration-tests
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
