### PR TITLE
feat(instruction):add AllocateAddress instruction

### DIFF
--- a/docusaurus/tari-docs/docs/wallet/submit-transaction/transaction-builder/instruction.md
+++ b/docusaurus/tari-docs/docs/wallet/submit-transaction/transaction-builder/instruction.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Instructions
 
-There are nine types of instructions. In most cases, you will not need to create raw instructions yourself but will instead use one of the methods provided by the Transaction Builder.
+There are ten types of instructions. In most cases, you will not need to create raw instructions yourself but will instead use one of the methods provided by the Transaction Builder.
 
 ## CreateAccount
 
@@ -103,6 +103,17 @@ DropAllProofsInWorkspace
   "CreateFreeTestCoins": {
     "revealed_amount": string,
     "output": ConfidentialOutput | null
+  }
+}
+```
+
+## AllocateAddress
+
+```json
+{
+  "AllocateAddress": {
+    "substate_type": string,
+    "workspace_id": string
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-builders",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/builders/src/transaction/TransactionBuilder.ts
+++ b/packages/builders/src/transaction/TransactionBuilder.ts
@@ -14,6 +14,7 @@ import {
   TransactionSignature,
   UnsignedTransaction,
   PublishedTemplateAddress,
+  SubstateType,
   TransactionArg,
 } from "@tari-project/tarijs-types";
 
@@ -147,6 +148,15 @@ export class TransactionBuilder implements Builder {
     return this.addInstruction({
       ClaimBurn: {
         claim,
+      },
+    });
+  }
+
+  public allocateAddress(substateType: SubstateType, workspaceId: string): this {
+    return this.addInstruction({
+      AllocateAddress: {
+        substate_type: substateType,
+        workspace_id: workspaceId,
       },
     });
   }

--- a/packages/tari_universe/package.json
+++ b/packages/tari_universe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-universe-signer",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-all",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/package.json
+++ b/packages/tarijs_types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-types",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/src/Instruction.ts
+++ b/packages/tarijs_types/src/Instruction.ts
@@ -1,4 +1,4 @@
-import { ComponentAddress, LogLevel, PublishedTemplateAddress } from "@tari-project/typescript-bindings";
+import { ComponentAddress, LogLevel, PublishedTemplateAddress, SubstateType } from "@tari-project/typescript-bindings";
 import { TransactionArg } from "./TransactionArg";
 import { ConfidentialClaim } from "./ConfidentialClaim";
 import { Amount } from "./Amount";
@@ -13,7 +13,8 @@ export type Instruction =
   | ClaimBurn
   | ClaimValidatorFees
   | DropAllProofsInWorkspace
-  | CreateFreeTestCoins;
+  | CreateFreeTestCoins
+  | AllocateAddress;
 
 export type CreateAccount = { CreateAccount: { owner_public_key: string; workspace_bucket: string | null } };
 export type CallFunction = {
@@ -29,4 +30,7 @@ export type ClaimValidatorFees = { ClaimValidatorFees: { epoch: number; validato
 export type DropAllProofsInWorkspace = "DropAllProofsInWorkspace";
 export type CreateFreeTestCoins = {
   CreateFreeTestCoins: { revealed_amount: Amount; output: ConfidentialOutput | null };
+};
+export type AllocateAddress = {
+  AllocateAddress: { substate_type: SubstateType; workspace_id: string };
 };

--- a/packages/tarijs_types/src/SubstateType.ts
+++ b/packages/tarijs_types/src/SubstateType.ts
@@ -1,0 +1,1 @@
+export type SubstateType = "Component" | "Resource" | "Vault" | "UnclaimedConfidentialOutput" | "NonFungible" | "TransactionReceipt" | "NonFungibleIndex" | "ValidatorFeePool" | "Template";

--- a/packages/tarijs_types/src/index.ts
+++ b/packages/tarijs_types/src/index.ts
@@ -16,6 +16,7 @@ export { Instruction } from "./Instruction";
 export { Transaction } from "./Transaction";
 export { SubstateDiff, DownSubstates, UpSubstates } from "./SubstateDiff";
 export { SubstateRequirement } from "./SubstateRequirement";
+export { SubstateType } from "./SubstateType";
 export {
   TransactionResult,
   SubmitTxResult,


### PR DESCRIPTION
Description
---

Adds `AllocateAddress` instruction, which is missing in the library.

Motivation and Context
---

Tari VS Code extension adds `AllocateAddress` building block.
The transactions are executed using `tari.js` library, where this instruction is missing.

How Has This Been Tested?
---

Added an integration test, which ran successfully.

What process can a PR reviewer use to test or verify this change?
---

```sh
$ cd packages/tarijs
$ WALLET_DAEMON_JSON_RPC_URL=http://127.0.0.1:12009/json_rpc pn run integration-tests
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new instruction type, AllocateAddress, for transaction building, allowing allocation of addresses for specific substate types and workspace IDs.
  - Added support for the SubstateType type, enhancing type safety and clarity when specifying substate categories.
- **Documentation**
  - Updated documentation to include the new AllocateAddress instruction and its JSON schema.
- **Tests**
  - Added integration tests to verify address allocation behavior and its expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->