### PR TITLE
fix(workspace): fix workspace reference format

### DIFF
--- a/docusaurus/tari-docs/package.json
+++ b/docusaurus/tari-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-docs",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docusaurus/tari-docs/package.json
+++ b/docusaurus/tari-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-docs",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-builders",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-builders",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/builders/src/helpers/workspace.ts
+++ b/packages/builders/src/helpers/workspace.ts
@@ -3,12 +3,8 @@ import { WorkspaceArg } from "@tari-project/tarijs-types";
 /**
  *
  * @param key workspace name
- * @returns encoded Uint8Array value
+ * @returns encoded hex value
  * @example
- * key: "0"   -> [ 48 ]
- * key: "0.0" -> [ 48, 46, 48 ]
- * key: "0.1" -> [ 48, 46, 49 ]
- *
  * key: "bucket"   -> "6275636b6574"
  * key: "bucket.0" -> "6275636b65742e30"
  * key: "bucket.1" -> "6275636b65742e31"

--- a/packages/builders/src/helpers/workspace.ts
+++ b/packages/builders/src/helpers/workspace.ts
@@ -9,13 +9,12 @@ import { WorkspaceArg } from "@tari-project/tarijs-types";
  * key: "0.0" -> [ 48, 46, 48 ]
  * key: "0.1" -> [ 48, 46, 49 ]
  *
- * key: "bucket"   -> [ 98, 117, 99, 107, 101, 116 ]
- * key: "bucket.0" -> [ 98, 117, 99, 107, 101, 116, 46, 48 ]
- * key: "bucket.1" -> [ 98, 117, 99, 107, 101, 116, 46, 49 ]
+ * key: "bucket"   -> "6275636b6574"
+ * key: "bucket.0" -> "6275636b65742e30"
+ * key: "bucket.1" -> "6275636b65742e31"
  */
-export function toWorkspace(key: string): number[] {
-  const encoder = new TextEncoder();
-  return Array.from(encoder.encode(key));
+export function toWorkspace(key: string): string {
+  return Buffer.from(key).toString("hex");
 }
 
 /**
@@ -23,10 +22,8 @@ export function toWorkspace(key: string): number[] {
  * @param key workspace name
  * @returns formatted Workspace data
  * @example
- * key: "bucket" -> { Workspace: [ 98, 117, 99, 107, 101, 116 ] }
+ * key: "bucket" -> { Workspace: "6275636b6574" }
  */
 export function fromWorkspace(key: string): WorkspaceArg {
-  const encoder = new TextEncoder();
-  const encodedKey = encoder.encode(key);
-  return { Workspace: Array.from(encodedKey) };
+  return { Workspace: Buffer.from(key).toString("hex") };
 }

--- a/packages/indexer_provider/package.json
+++ b/packages/indexer_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/indexer-provider",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/indexer_provider/package.json
+++ b/packages/indexer_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/indexer-provider",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/metamask_signer/package.json
+++ b/packages/metamask_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/metamask-signer",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/metamask_signer/package.json
+++ b/packages/metamask_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/metamask-signer",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_permissions/package.json
+++ b/packages/tari_permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-permissions",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_permissions/package.json
+++ b/packages/tari_permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-permissions",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_provider/package.json
+++ b/packages/tari_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-provider",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_provider/package.json
+++ b/packages/tari_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-provider",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_signer/package.json
+++ b/packages/tari_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-signer",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_signer/package.json
+++ b/packages/tari_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-signer",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_universe/package.json
+++ b/packages/tari_universe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-universe-signer",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_universe/package.json
+++ b/packages/tari_universe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-universe-signer",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-all",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-all",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/package.json
+++ b/packages/tarijs_types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-types",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/package.json
+++ b/packages/tarijs_types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-types",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/src/Instruction.ts
+++ b/packages/tarijs_types/src/Instruction.ts
@@ -23,7 +23,7 @@ export type CallFunction = {
 export type CallMethod = {
   CallMethod: { component_address: ComponentAddress; method: string; args: Array<TransactionArg> };
 };
-export type PutLastInstructionOutputOnWorkspace = { PutLastInstructionOutputOnWorkspace: { key: number[] } };
+export type PutLastInstructionOutputOnWorkspace = { PutLastInstructionOutputOnWorkspace: { key: string } };
 export type EmitLog = { EmitLog: { level: LogLevel; message: string } };
 export type ClaimBurn = { ClaimBurn: { claim: ConfidentialClaim } };
 export type ClaimValidatorFees = { ClaimValidatorFees: { epoch: number; validator_public_key: string } };

--- a/packages/tarijs_types/src/Workspace.ts
+++ b/packages/tarijs_types/src/Workspace.ts
@@ -1,3 +1,3 @@
 export interface WorkspaceArg {
-  Workspace: number[];
+  Workspace: string;
 }

--- a/packages/wallet_daemon/package.json
+++ b/packages/wallet_daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-daemon-signer",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet_daemon/package.json
+++ b/packages/wallet_daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-daemon-signer",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-connect-signer",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-connect-signer",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Description
---

Updates format of workspace references from byte array to hex string.

**Updated version to v0.6.0, since it is a breaking change**

Motivation and Context
---

Due to recent updates in `tari-dan`, transactions, that use workspaces started to fail in `tari.js`.
This was due to expected format change. Now workspaces must be encoded as a hex string.

How Has This Been Tested?
---

Added an integration test, which ran successfully.

What process can a PR reviewer use to test or verify this change?
---

```sh
$ cd packages/tarijs
$ WALLET_DAEMON_JSON_RPC_URL=http://127.0.0.1:12009/json_rpc pn run integration-tests
```

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for using hexadecimal string keys in workspace-related functionality, improving consistency and usability.

- **Bug Fixes**
  - Updated workspace key handling to use hex strings instead of numeric arrays, ensuring better compatibility across the platform.

- **Tests**
  - Added an integration test to verify transaction submission using the updated workspace key format.

- **Chores**
  - Updated package versions to 0.6.0 across all modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->