### PR TITLE
feat: add additional signer methods

### DIFF
--- a/docusaurus/tari-docs/package.json
+++ b/docusaurus/tari-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-docs",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "keywords": [],

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-builders",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/indexer_provider/package.json
+++ b/packages/indexer_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/indexer-provider",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/metamask_signer/package.json
+++ b/packages/metamask_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/metamask-signer",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/metamask_signer/src/index.ts
+++ b/packages/metamask_signer/src/index.ts
@@ -15,9 +15,13 @@ import {
 import { MetaMaskInpageProvider } from "@metamask/providers";
 import { connectSnap, getSnap, isFlask, Snap } from "./utils";
 import {
+  AccountGetResponse,
+  AccountsListRequest,
+  AccountsListResponse,
   ConfidentialViewVaultBalanceRequest,
   ListAccountNftRequest,
   ListAccountNftResponse,
+  WalletGetInfoResponse,
 } from "@tari-project/typescript-bindings";
 
 export const MetamaskNotInstalled = "METAMASK_NOT_INSTALLED";
@@ -84,8 +88,16 @@ export class MetamaskTariSigner implements TariSigner {
     };
   }
 
+  async accountsList(req: AccountsListRequest): Promise<AccountsListResponse> {
+    return await this.metamaskRequest("accountsList", req);
+  }
+
   async getAccount(): Promise<AccountData> {
     return (await this.metamaskRequest("getAccountData", { account_id: 0 })) as any;
+  }
+
+  async getAccountByAddress(address: string): Promise<AccountGetResponse> {
+    return await this.metamaskRequest("accountsGet", { address });
   }
 
   async getSubstate(substate_address: string): Promise<Substate> {
@@ -203,6 +215,11 @@ export class MetamaskTariSigner implements TariSigner {
 
   public async getNftsList(req: ListAccountNftRequest): Promise<ListAccountNftResponse> {
     const resp = (await this.metamaskRequest("getNftsList", req)) as ListAccountNftResponse;
+    return resp;
+  }
+
+  public async getWalletInfo(): Promise<WalletGetInfoResponse> {
+    const resp = (await this.metamaskRequest("getWalletInfo", {})) as WalletGetInfoResponse;
     return resp;
   }
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-permissions",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/react-mui-connect-button/package.json
+++ b/packages/react-mui-connect-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/react-mui-connect-button",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "React component to connect your website to the Tari Ootle Wallet",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_provider/package.json
+++ b/packages/tari_provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-provider",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_signer/package.json
+++ b/packages/tari_signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-signer",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_signer/src/TariSigner.ts
+++ b/packages/tari_signer/src/TariSigner.ts
@@ -1,7 +1,11 @@
 import type {
+  AccountGetResponse,
+  AccountsListRequest,
+  AccountsListResponse,
   ConfidentialViewVaultBalanceRequest,
   ListAccountNftRequest,
   ListAccountNftResponse,
+  WalletGetInfoResponse,
 } from "@tari-project/typescript-bindings";
 import {
   GetTransactionResultResponse,
@@ -18,7 +22,9 @@ import {
 export interface TariSigner {
   signerName: string;
   isConnected(): boolean;
+  accountsList(req: AccountsListRequest): Promise<AccountsListResponse>;
   getAccount(): Promise<AccountData>;
+  getAccountByAddress(address: string): Promise<AccountGetResponse>;
   getSubstate(substate_address: string): Promise<Substate>;
   submitTransaction(req: SubmitTransactionRequest): Promise<SubmitTransactionResponse>;
   getTransactionResult(transactionId: string): Promise<GetTransactionResultResponse>;
@@ -27,4 +33,5 @@ export interface TariSigner {
   getConfidentialVaultBalances(req: ConfidentialViewVaultBalanceRequest): Promise<VaultBalances>;
   listSubstates(req: ListSubstatesRequest): Promise<ListSubstatesResponse>;
   getNftsList(req: ListAccountNftRequest): Promise<ListAccountNftResponse>;
+  getWalletInfo(): Promise<WalletGetInfoResponse>;
 }

--- a/packages/tari_universe/package.json
+++ b/packages/tari_universe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tari-universe-signer",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tari_universe/src/signer.ts
+++ b/packages/tari_universe/src/signer.ts
@@ -14,10 +14,14 @@ import { SignerRequest, SignerMethodNames, SignerReturnType, TariUniverseSignerP
 import { sendSignerCall } from "./utils";
 import { TariSigner } from "@tari-project/tari-signer";
 import {
+  AccountGetResponse,
   AccountsGetBalancesResponse,
+  AccountsListRequest,
+  AccountsListResponse,
   ConfidentialViewVaultBalanceRequest,
   ListAccountNftRequest,
   ListAccountNftResponse,
+  WalletGetInfoResponse,
 } from "@tari-project/typescript-bindings";
 
 export class TariUniverseSigner implements TariSigner {
@@ -83,8 +87,16 @@ export class TariUniverseSigner implements TariSigner {
     return this.sendRequest({ methodName: "requestParentSize", args: [] });
   }
 
+  public async accountsList(req: AccountsListRequest): Promise<AccountsListResponse> {
+    return this.sendRequest({ methodName: "accountsList", args: [req] });
+  }
+
   public async getAccount(): Promise<AccountData> {
     return this.sendRequest({ methodName: "getAccount", args: [] });
+  }
+
+  public async getAccountByAddress(address: string): Promise<AccountGetResponse> {
+    return this.sendRequest({ methodName: "getAccountByAddress", args: [address] });
   }
 
   public async getAccountBalances(componentAddress: string): Promise<AccountsGetBalancesResponse> {
@@ -125,5 +137,9 @@ export class TariUniverseSigner implements TariSigner {
 
   public async getNftsFromAccountBalances(req: ListAccountNftFromBalancesRequest): Promise<ListAccountNftResponse> {
     return this.sendRequest({ methodName: "getNftsFromAccountBalances", args: [req] });
+  }
+
+  public async getWalletInfo(): Promise<WalletGetInfoResponse> {
+    return this.sendRequest({ methodName: "getWalletInfo", args: [] });
   }
 }

--- a/packages/tarijs/package.json
+++ b/packages/tarijs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-all",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/tarijs_types/package.json
+++ b/packages/tarijs_types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/tarijs-types",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet_daemon/package.json
+++ b/packages/wallet_daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-daemon-signer",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/wallet_daemon/src/signer.ts
+++ b/packages/wallet_daemon/src/signer.ts
@@ -16,12 +16,16 @@ import {
   ListSubstatesRequest,
 } from "@tari-project/tarijs-types";
 import {
+  AccountGetResponse,
+  AccountsListRequest,
+  AccountsListResponse,
   ConfidentialViewVaultBalanceRequest,
   KeyBranch,
   ListAccountNftRequest,
   ListAccountNftResponse,
   substateIdToString,
   SubstatesListRequest,
+  WalletGetInfoResponse,
 } from "@tari-project/typescript-bindings";
 
 export const WalletDaemonNotConnected = "WALLET_DAEMON_NOT_CONNECTED";
@@ -133,6 +137,11 @@ export class WalletDaemonTariSigner implements TariSigner {
     };
   }
 
+  public async accountsList(req: AccountsListRequest): Promise<AccountsListResponse> {
+    const resp = await this.client.accountsList(req);
+    return resp;
+  }
+
   public async getAccount(): Promise<AccountData> {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const { account, public_key } = (await this.client.accountsGetDefault({})) as any;
@@ -156,6 +165,15 @@ export class WalletDaemonTariSigner implements TariSigner {
         token_symbol: b.token_symbol,
       })),
     };
+  }
+
+  public async getAccountByAddress(address: string): Promise<AccountGetResponse> {
+    const resp = await this.client.accountsGet({
+      name_or_address: {
+        ComponentAddress: address,
+      },
+    });
+    return resp;
   }
 
   public async getAccountBalances(componentAddress: string): Promise<unknown> {
@@ -254,5 +272,10 @@ export class WalletDaemonTariSigner implements TariSigner {
 
   public async getNftsList(req: ListAccountNftRequest): Promise<ListAccountNftResponse> {
     return await this.client.nftsList(req);
+  }
+
+  public async getWalletInfo(): Promise<WalletGetInfoResponse> {
+    const resp = await this.client.walletGetInfo();
+    return resp;
   }
 }

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wallet-connect-signer",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "",
   "type": "module",
   "publishConfig": {

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -15,12 +15,16 @@ import {
   SubmitTransactionResponse,
 } from "@tari-project/tarijs-types";
 import {
+  AccountGetResponse,
+  AccountsListRequest,
+  AccountsListResponse,
   ConfidentialViewVaultBalanceRequest,
   KeyBranch,
   ListAccountNftRequest,
   ListAccountNftResponse,
   substateIdToString,
   TransactionSubmitRequest,
+  WalletGetInfoResponse,
 } from "@tari-project/typescript-bindings";
 import { TariPermission } from "@tari-project/tari-permissions";
 
@@ -39,6 +43,7 @@ const walletConnectParams = {
         "tari_createFreeTestCoins",
         "tari_listSubstates",
         "tari_getNftsList",
+        "tari_getWalletInfo",
       ],
       chains: ["tari:devnet"],
       events: [],
@@ -154,6 +159,11 @@ export class WalletConnectTariSigner implements TariSigner {
     return this.wcSession !== null;
   }
 
+  async accountsList(req: AccountsListRequest): Promise<AccountsListResponse> {
+    const res = await this.sendRequest("tari_accountsList", req);
+    return res as AccountsListResponse;
+  }
+
   async getAccount(): Promise<AccountData> {
     const { account, public_key } = await this.sendRequest("tari_getDefaultAccount", {});
     const { balances } = await this.sendRequest("tari_getAccountBalances", {
@@ -175,6 +185,15 @@ export class WalletConnectTariSigner implements TariSigner {
         token_symbol: b.token_symbol,
       })),
     };
+  }
+
+  async getAccountByAddress(address: string): Promise<AccountGetResponse> {
+    const res = await this.sendRequest("tari_getAccountByAddress", {
+      name_or_address: {
+        ComponentAddress: address,
+      },
+    });
+    return res as AccountGetResponse;
   }
 
   async getSubstate(substate_address: string): Promise<Substate> {
@@ -295,5 +314,10 @@ export class WalletConnectTariSigner implements TariSigner {
     };
     const res = await this.sendRequest(method, params);
     return res as ListAccountNftResponse;
+  }
+
+  public async getWalletInfo(): Promise<WalletGetInfoResponse> {
+    const res = await this.sendRequest("tari_getWalletInfo", {});
+    return res as WalletGetInfoResponse;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.7.15
       version: 1.7.15
     '@tari-project/typescript-bindings':
-      specifier: '>=1.14.0'
-      version: 1.14.0
+      specifier: '>=1.15.0'
+      version: 1.15.0
     '@tari-project/wallet_jrpc_client':
       specifier: ^1.7.2
       version: 1.7.2
@@ -181,7 +181,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -203,7 +203,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
         version: 1.7.2
@@ -228,7 +228,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -290,7 +290,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -306,7 +306,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -328,7 +328,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
         version: 1.7.2
@@ -371,7 +371,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@tari-project/wallet-connect-signer':
         specifier: workspace:^
         version: link:../walletconnect
@@ -396,7 +396,7 @@ importers:
     dependencies:
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@thames/monads':
         specifier: ^0.7.0
         version: 0.7.0
@@ -424,7 +424,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
         version: 1.7.2
@@ -455,7 +455,7 @@ importers:
         version: link:../tarijs_types
       '@tari-project/typescript-bindings':
         specifier: 'catalog:'
-        version: 1.14.0
+        version: 1.15.0
       '@walletconnect/universal-provider':
         specifier: 'catalog:'
         version: 2.21.3(typescript@5.8.3)(zod@3.25.76)
@@ -2552,8 +2552,8 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tari-project/typescript-bindings@1.14.0':
-    resolution: {integrity: sha512-THbz3q0l6REdTymGy5ZKVjUEIp2c5ww5RI3bGyG519ZuL98qCPPw/4pISds3yeuWQlL79nSJkaMJKAzl+gHeqw==}
+  '@tari-project/typescript-bindings@1.15.0':
+    resolution: {integrity: sha512-S9TdEtjFw8dxljzA08GXOdGLy0hwmcKBZQg4SN8eCIn8go+Piy8w57fg991aTbrwiMLLqa55zZxBkCaI8OO8XQ==}
 
   '@tari-project/wallet_jrpc_client@1.7.2':
     resolution: {integrity: sha512-Eua8vszl8Wyd9whA6Q9PgV457aF01NcCk8EZvLkTJjH1LPk7fZ+Q3mLorIOHrpNr9TZ/Ffgq4G11aRRxthbgpw==}
@@ -10311,11 +10311,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tari-project/typescript-bindings@1.14.0': {}
+  '@tari-project/typescript-bindings@1.15.0': {}
 
   '@tari-project/wallet_jrpc_client@1.7.2':
     dependencies:
-      '@tari-project/typescript-bindings': 1.14.0
+      '@tari-project/typescript-bindings': 1.15.0
 
   '@thames/monads@0.7.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   vitest: ^3.0.4
   vite: ^6.1.0
   "@types/node": ^22.13.1
-  "@tari-project/typescript-bindings": ">=1.14.0"
+  "@tari-project/typescript-bindings": ">=1.15.0"
   "@tari-project/wallet_jrpc_client": ^1.7.2
   "@metamask/providers": ^18.2.0
   "@walletconnect/universal-provider": 2.21.3 


### PR DESCRIPTION
Description
---

Adds the following methods to TariSigner:
- accountsList
- getAccountByAddress
- getWalletInfo

Motivation and Context
---

Flow editor needs new functionality.
First, it needs to determine the network, that the wallet connection is bound to. It will be returned as part of `getWalletInfo` response.
Second, the editor has to list available accounts and get their details. That is what `accountsList` and `getAccountByAddress` are for.

How Has This Been Tested?
---

Breaking Changes
---

- [x] None
- [ ] Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Describe the breaking change -->
