### PR TITLE
fix: example apps, update wasm, fix signers & providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ const result = await sendTransaction(provider, signer, unsignedTx);
 import { SecretKeyWallet } from "@tari-project/ootle-secret-key-wallet";
 
 // Generate a fresh wallet with a view-only key (for stealth output scanning)
-const wallet = SecretKeyWallet.randomWithViewKey();
+const wallet = SecretKeyWallet.randomWithViewKey(Network.Esmeralda);
 
 // Or restore from an existing key (Uint8Array)
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda);
 ```
 
 ---
@@ -85,7 +85,7 @@ Implemented by `IndexerProvider`. Provides:
 - `resolveInputs(inputs)` — fills in missing versions before signing
 - `submitTransaction(envelope)`
 - `getTransactionResult(txId)`
-- `listSubstates(params)` / `getTemplateDefinition(address)`
+- `listRecentTransactions(params)` / `getTemplateDefinition(address)`
 
 ### `Signer` — produces signatures
 
@@ -252,7 +252,7 @@ Returns the well-known indexer URL for a network. Currently returns URLs for `Lo
 import { defaultIndexerUrl, Network } from "@tari-project/ootle";
 
 const url = defaultIndexerUrl(Network.Esmeralda);
-// "http://217.182.93.35:50124"
+// "https://ootle-indexer-a.tari.com"
 ```
 
 ---
@@ -270,7 +270,7 @@ import {
   PendingTransaction,
   resolveWantInputs,
 } from "@tari-project/ootle-indexer";
-import type { WantInput } from "@tari-project/ootle-indexer";
+import type { WantInput, TransactionEntry, TemplateMetadata } from "@tari-project/ootle-indexer";
 ```
 
 #### `ProviderBuilder`
@@ -295,7 +295,7 @@ const provider = await IndexerProvider.connect({ url, network });
 const substate = await provider.getSubstate("component_0x…");
 const substates = await provider.fetchSubstates([id1, id2]);
 const template = await provider.getTemplateDefinition(templateAddress);
-const list = await provider.listSubstates({ filterByType: "Component", limit: 50 });
+const list = await provider.listRecentTransactions({ limit: 5, last_id: null });
 
 // Submit
 const { transaction_id } = await provider.submitTransaction(envelope);
@@ -365,19 +365,19 @@ Implements `Signer`. Holds an account secret key and an optional view-only key (
 
 ```ts
 // Generate a new random wallet with a view-only key (for stealth support)
-const wallet = SecretKeyWallet.randomWithViewKey();
+const wallet = SecretKeyWallet.randomWithViewKey(Network.Esmeralda);
 
 // Restore from a stored secret key (Uint8Array)
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda);
 
 // Restore with both account key and view-only key
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey, viewOnlySecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda, viewOnlySecretKey);
 
 // Restore from both secret and public keys (e.g. from a keystore)
-const wallet = SecretKeyWallet.fromKeypair(accountSecretKey, publicKey);
+const wallet = SecretKeyWallet.fromKeypair(ownerSecretKey, publicKey, Network.Esmeralda);
 
 // With view-only key for stealth
-const wallet = SecretKeyWallet.fromKeypair(accountSecretKey, publicKey, viewOnlySecretKey);
+const wallet = SecretKeyWallet.fromKeypair(ownerSecretKey, publicKey, Network.Esmeralda, viewOnlySecretKey);
 
 // Sign a transaction
 const signatures = await wallet.signTransaction(unsignedTx);
@@ -391,7 +391,7 @@ const viewKey = wallet.getViewOnlySecret();
 Generates a one-time throwaway keypair. Used in privacy-preserving transactions where no link to the sender's identity should exist. The key is discarded when the object is garbage-collected.
 
 ```ts
-const signer = EphemeralKeySigner.generate();
+const signer = EphemeralKeySigner.generate(); // defaults to Esmeralda
 const signed = await signTransaction([signer], unsignedTx);
 ```
 
@@ -494,7 +494,7 @@ Requires `tari_ootle_walletd` running locally. Default endpoint: `http://127.0.0
 
 ### indexer-explorer
 
-Browse on-chain substates. Look up components and resources by ID, or browse recent substates from the indexer.
+Browse on-chain state. Look up substates by ID, or browse recent transactions from the indexer.
 
 ```sh
 cd examples/indexer-explorer
@@ -603,7 +603,7 @@ tari.js/
 │   └── ootle-wallet-daemon-signer/   Remote wallet daemon signer
 ├── examples/
 │   ├── connect-button/               Wallet connection demo
-│   ├── indexer-explorer/             Read-only substate browser
+│   ├── indexer-explorer/             Read-only transaction/substate browser
 │   └── template-inspector/           Template ABI viewer
 ├── docs/                             Starlight documentation site
 ├── scripts/                          CI and utility scripts

--- a/docs/src/content/docs/chain-state/substates.md
+++ b/docs/src/content/docs/chain-state/substates.md
@@ -23,35 +23,17 @@ const substates = await provider.fetchSubstates([
 ]);
 ```
 
-## List substates
+## List recent transactions
 
-Query substates by type with pagination:
+Query recent transactions from the indexer:
 
 ```ts
-const result = await provider.listSubstates({
-  filterByType: "Component",
-  limit: 50,
-  offset: 0,
-});
+const result = await provider.listRecentTransactions({ limit: 5, last_id: null });
 
-for (const item of result.substates) {
-  console.log(item.substate_id, item.version);
+for (const tx of result.transactions) {
+  console.log(tx.transaction_id, tx.created_at);
 }
 ```
-
-### Substate types
-
-The `filterByType` parameter accepts these values:
-
-- `Component`
-- `Resource`
-- `Vault`
-- `UnclaimedConfidentialOutput`
-- `NonFungible`
-- `NonFungibleIndex`
-- `TransactionReceipt`
-- `Template`
-- `ValidatorFeePool`
 
 ## Get a transaction result
 

--- a/docs/src/content/docs/getting-started/provider-and-signer.md
+++ b/docs/src/content/docs/getting-started/provider-and-signer.md
@@ -13,7 +13,7 @@ A `Provider` gives read-only access to the Ootle network:
 interface Provider {
   getSubstate(id: string): Promise<IndexerGetSubstateResponse>;
   fetchSubstates(ids: string[]): Promise<GetSubstatesResponse>;
-  listSubstates(params: ListSubstatesRequest): Promise<ListSubstatesResponse>;
+  listRecentTransactions(params: ListRecentTransactionsRequest): Promise<ListRecentTransactionsResponse>;
   getTemplateDefinition(address: string): Promise<GetTemplateDefinitionResponse>;
   submitTransaction(envelope: TransactionEnvelope): Promise<IndexerSubmitTransactionResponse>;
   getTransactionResult(txId: string): Promise<IndexerGetTransactionResultResponse>;

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -61,12 +61,13 @@ const result = await sendTransaction(provider, signer, unsignedTx);
 
 ```ts
 import { SecretKeyWallet } from "@tari-project/ootle-secret-key-wallet";
+import { Network } from "@tari-project/ootle";
 
 // Generate a fresh wallet with a view-only key (for stealth output scanning)
-const wallet = SecretKeyWallet.randomWithViewKey();
+const wallet = SecretKeyWallet.randomWithViewKey(Network.Esmeralda);
 
 // Or restore from an existing secret key
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda);
 
 const signatures = await wallet.signTransaction(unsignedTx);
 ```

--- a/docs/src/content/docs/providers/indexer-provider.md
+++ b/docs/src/content/docs/providers/indexer-provider.md
@@ -41,11 +41,8 @@ const substate = await provider.getSubstate("component_0x…");
 // Multiple substates
 const substates = await provider.fetchSubstates([id1, id2]);
 
-// List substates by type
-const list = await provider.listSubstates({
-  filterByType: "Component",
-  limit: 50,
-});
+// List recent transactions
+const list = await provider.listRecentTransactions({ limit: 5, last_id: null });
 
 // Template definition (ABI)
 const template = await provider.getTemplateDefinition(templateAddress);

--- a/docs/src/content/docs/signers/secret-key-wallet.md
+++ b/docs/src/content/docs/signers/secret-key-wallet.md
@@ -13,18 +13,19 @@ The secret key lives unencrypted in memory. For production use, prefer [`WalletD
 
 ```ts
 import { SecretKeyWallet } from "@tari-project/ootle-secret-key-wallet";
+import { Network } from "@tari-project/ootle";
 
 // Generate a new random wallet with a view-only key (for stealth support)
-const wallet = SecretKeyWallet.randomWithViewKey();
+const wallet = SecretKeyWallet.randomWithViewKey(Network.Esmeralda);
 
 // Restore from an existing secret key
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda);
 
 // Restore with both account key and view-only key
-const wallet = SecretKeyWallet.fromSecretKey(accountSecretKey, viewOnlySecretKey);
+const wallet = SecretKeyWallet.fromSecretKey(ownerSecretKey, Network.Esmeralda, viewOnlySecretKey);
 
 // Restore from both secret and public keys (e.g. from a keystore)
-const wallet = SecretKeyWallet.fromKeypair(accountSecretKey, publicKey);
+const wallet = SecretKeyWallet.fromKeypair(ownerSecretKey, publicKey, Network.Esmeralda);
 ```
 
 ## Sign a transaction
@@ -51,6 +52,6 @@ For privacy-preserving transactions where no link to the sender should exist, us
 import { EphemeralKeySigner } from "@tari-project/ootle-secret-key-wallet";
 import { signTransaction } from "@tari-project/ootle";
 
-const signer = EphemeralKeySigner.generate();
+const signer = EphemeralKeySigner.generate(); // defaults to Esmeralda
 const signed = await signTransaction([signer], unsignedTx);
 ```

--- a/examples/connect-button/src/hooks/useWalletDaemon.ts
+++ b/examples/connect-button/src/hooks/useWalletDaemon.ts
@@ -38,7 +38,6 @@ export function useWalletDaemon(): UseWalletDaemon {
   const [state, setState] = useState<WalletState>(INITIAL);
 
   const connect = useCallback(async (options: WalletDaemonSignerOptions) => {
-    console.debug("options", options);
     setState((s) => ({ ...s, status: "connecting", error: null }));
     try {
       // WalletDaemonSigner.connect() reaches out to the daemon, fetches the

--- a/examples/indexer-explorer/README.md
+++ b/examples/indexer-explorer/README.md
@@ -1,6 +1,6 @@
 # indexer-explorer
 
-Browse on-chain substates using the Ootle indexer. No wallet, no signing, no local services — this is a pure **read** example that connects to the public Esmeralda testnet out of the box.
+Browse on-chain state using the Ootle indexer. No wallet, no signing, no local services — this is a pure **read** example that connects to the public Esmeralda testnet out of the box.
 
 ---
 
@@ -10,9 +10,9 @@ Tari Ootle is a smart contract platform. Every piece of on-chain state (accounts
 
 The **indexer** is a service that watches the network and indexes those substates so web apps can query them over HTTP. This example shows you how to:
 
-- Connect to an indexer using the `IndexerProvider` from `@tari-project/ootle`
+- Connect to an indexer using the `IndexerProvider` from `@tari-project/ootle-indexer`
 - Look up a specific substate by ID
-- List recent substates and browse them by type
+- List recent transactions and browse their substate inputs
 
 Think of the indexer like a blockchain explorer (e.g. Etherscan) — read-only, no wallet required.
 
@@ -22,7 +22,7 @@ Think of the indexer like a blockchain explorer (e.g. Etherscan) — read-only, 
 
 - How to connect to the Ootle indexer from a React app
 - How to query a substate by ID
-- How to list and paginate recent substates
+- How to list recent transactions and inspect their inputs
 - The `useIndexer` React hook pattern used across Ootle dApp examples
 
 ---
@@ -62,7 +62,7 @@ pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-The public Esmeralda testnet indexer URL is pre-filled. Click **Connect to Indexer** — you should immediately start seeing recent substates.
+The public Esmeralda testnet indexer URL is pre-filled. Click **Connect to Indexer** — you should immediately start seeing recent transactions.
 
 ---
 
@@ -72,12 +72,7 @@ The public Esmeralda testnet indexer URL is pre-filled. Click **Connect to Index
 
 **Substate lookup** — Enter any substate ID (e.g. `component_...` or `resource_...`) and click **Look up** to fetch and display it as formatted JSON.
 
-**Recent substates list** — A table of the latest substates indexed, with coloured type badges:
-- `component` — a deployed smart contract instance
-- `resource` — a token type or other on-chain resource definition
-- `vault` — a container holding tokens
-
-Click any row to copy its ID into the lookup panel.
+**Recent transactions** — A list of the latest transactions, each showing its transaction ID, timestamp, and substate inputs. Click any substate input to copy its ID into the lookup panel.
 
 ---
 
@@ -85,7 +80,7 @@ Click any row to copy its ID into the lookup panel.
 
 | Network | Indexer URL |
 |---------|------------|
-| Esmeralda testnet (public) | `http://217.182.93.35:50124` |
+| Esmeralda testnet (public) | `https://ootle-indexer-a.tari.com` |
 | Local dev | `http://localhost:12500` |
 
 To run a local indexer, see the [tari-ootle releases](https://github.com/tari-project/tari-ootle/releases).
@@ -95,12 +90,12 @@ To run a local indexer, see the [tari-ootle releases](https://github.com/tari-pr
 ## Troubleshooting
 
 **"Connection failed" or network error**
-The public indexer may be temporarily unavailable, or your network blocks HTTP (non-HTTPS) requests. Try refreshing after a moment. If you are behind a strict firewall or corporate VPN, the request to `217.182.93.35` may be blocked.
+The public indexer may be temporarily unavailable. Try refreshing after a moment. If you are behind a strict firewall or corporate VPN, the request to `ootle-indexer-a.tari.com` may be blocked.
 
 **CORS error in browser console**
-Some browser configurations block cross-origin HTTP requests. Try a different browser, or run a local indexer at `http://localhost:12500` instead.
+Some browser configurations block cross-origin requests. Try a different browser, or run a local indexer at `http://localhost:12500` instead.
 
-**Empty substate list**
+**Empty transaction list**
 The indexer may have just restarted and is catching up. Wait a moment and click **Connect** again.
 
 **Substate lookup returns "not found"**
@@ -114,8 +109,8 @@ Substate IDs are case-sensitive and must be complete (no partial IDs). Double-ch
 indexer-explorer/
 ├── src/
 │   ├── hooks/
-│   │   └── useIndexer.ts    # Wraps IndexerProvider; exposes getSubstate, listSubstates
-│   ├── App.tsx              # Connect form, substate lookup panel, recent substates list
+│   │   └── useIndexer.ts    # Wraps IndexerProvider; exposes getSubstate, getRecentTransactions
+│   ├── App.tsx              # Connect form, substate lookup panel, recent transactions list
 │   ├── App.css              # Styles
 │   ├── index.css            # CSS variables and reset
 │   └── main.tsx             # React entry point

--- a/examples/indexer-explorer/src/App.css
+++ b/examples/indexer-explorer/src/App.css
@@ -239,10 +239,11 @@
 .substate-list {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 6px;
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
+  padding: 4px;
 }
 
 .substate-row {
@@ -362,7 +363,9 @@
   border-radius: 10px;
   cursor: pointer;
   font-family: inherit;
-  transition: background 0.15s, opacity 0.15s;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -389,7 +392,9 @@
   font-family: inherit;
   white-space: nowrap;
   flex-shrink: 0;
-  transition: background 0.15s, opacity 0.15s;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 
 .btn-secondary:hover:not(:disabled) {
@@ -413,7 +418,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  transition: border-color 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .btn-ghost:hover:not(:disabled) {

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { Network, defaultIndexerUrl } from "@tari-project/ootle";
+import type { TransactionEntry } from "@tari-project/ootle-indexer";
 import { useIndexer } from "./hooks/useIndexer";
-import type { SubstateEntry } from "./hooks/useIndexer";
 import "./App.css";
+import React from "react";
 
 // Public Esmeralda testnet indexer — no local setup required.
 // Swap for http://localhost:18300 (with Network.LocalNet) when using a local indexer.
@@ -18,7 +19,7 @@ const NETWORKS: { label: string; value: Network }[] = [
 ];
 
 export function App() {
-  const { status, error, connect, disconnect, getSubstate, getIndexerInfo } = useIndexer();
+  const { status, error, connect, disconnect, getSubstate, getRecentTransactions } = useIndexer();
 
   // Connection form state
   const [url, setUrl] = useState(DEFAULT_URL);
@@ -30,7 +31,7 @@ export function App() {
   const [lookupError, setLookupError] = useState<string | null>(null);
   const [lookupLoading, setLookupLoading] = useState(false);
 
-  const [info, setInfo] = useState<Record<string, unknown>>({});
+  const [txList, setTxList] = useState<TransactionEntry[]>([]);
   const [listLoading, setListLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
 
@@ -54,18 +55,20 @@ export function App() {
   };
 
   useEffect(() => {
-    if (status !== "connected") return;
+    if (status !== "connected" || txList?.length > 0) return;
     setListLoading(true);
-    getIndexerInfo()
-      .then((r) => {
-        setInfo(r);
+    getRecentTransactions().then(
+      (txs) => {
+        setTxList(txs);
         setListLoading(false);
-      })
-      .catch((e) => {
-        setListError(e instanceof Error ? e.message : "Failed to fetch info");
+      },
+      (err) => {
+        console.error(err);
+        setListError(err instanceof Error ? err.message : "Failed to fetch recent transactions");
         setListLoading(false);
-      });
-  }, [getIndexerInfo, status]);
+      },
+    );
+  }, [getRecentTransactions, status, txList?.length]);
 
   // ── Connect screen ──────────────────────────────────────────────────────────
   if (status !== "connected") {
@@ -188,25 +191,20 @@ export function App() {
           {lookupResult !== null && <pre className="json-view">{JSON.stringify(lookupResult, null, 2)}</pre>}
         </section>
 
-        {/* Recent substates */}
+        {/* Recent transactions */}
         <section className="panel">
           <div className="panel-header">
-            <h2 className="panel-title">Indexer Info</h2>
+            <h2 className="panel-title">Recent Transactions</h2>
             <button className="btn-ghost small" disabled={listLoading}>
               {listLoading ? <Spinner /> : "Refresh"}
             </button>
           </div>
 
-          {Object.entries(info)?.length > 0
-            ? Object.entries(info).map(([k, v]) => (
-                // TEMP
-                <div key={k}>
-                  <p>
-                    <b>{k}</b>: <span>{v?.toString()}</span>
-                  </p>
-                </div>
-              ))
-            : null}
+          {txList?.map((tx) => (
+            <React.Fragment key={tx.transaction_id}>
+              <TransactionRow transaction={tx} />
+            </React.Fragment>
+          ))}
 
           {listError && (
             <div className="error-banner" role="alert">
@@ -221,27 +219,16 @@ export function App() {
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
-function SubstateRow({ substate, onSelect }: { substate: SubstateEntry; onSelect: (id: string) => void }) {
-  const typeTag = substateType(substate.substate_id);
+function TransactionRow({ transaction }: { transaction: TransactionEntry }) {
   return (
-    <div className="substate-row">
-      <div className="substate-row-left">
-        <span className={`type-badge type-${typeTag}`}>{typeTag}</span>
-        <span
-          className="substate-id mono"
-          title={substate.substate_id}
-          onClick={() => onSelect(substate.substate_id)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => e.key === "Enter" && onSelect(substate.substate_id)}
-        >
-          {truncate(substate.substate_id, 12, 10)}
+    <div className="tx-row">
+      <div className="tx-row-left">
+        <span className="tx-id mono" title={transaction.transaction_id}>
+          {truncate(transaction.transaction_id, 12, 10)}
         </span>
-        {substate.module_name && <span className="module-name">{substate.module_name}</span>}
       </div>
-      <div className="substate-row-right">
-        <span className="version-badge">v{substate.version}</span>
-        <span className="timestamp">{formatTime(substate.timestamp)}</span>
+      <div className="tx-row-right">
+        <span className="timestamp">{formatTime(transaction.created_at)}</span>
       </div>
     </div>
   );
@@ -266,11 +253,6 @@ function TariLogo({ size = 40 }: { size?: number }) {
 function truncate(str: string, head = 10, tail = 8): string {
   if (str.length <= head + tail + 3) return str;
   return `${str.slice(0, head)}…${str.slice(-tail)}`;
-}
-
-function substateType(id: string): string {
-  const prefix = id.split("_")[0] ?? "unknown";
-  return prefix.toLowerCase();
 }
 
 function formatTime(ts: string): string {

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -202,7 +202,7 @@ export function App() {
 
           {txList?.map((tx) => (
             <React.Fragment key={tx.transaction_id}>
-              <TransactionRow transaction={tx} />
+              <TransactionRow transaction={tx} onSelect={setLookupId} />
             </React.Fragment>
           ))}
 
@@ -219,18 +219,36 @@ export function App() {
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
-function TransactionRow({ transaction }: { transaction: TransactionEntry }) {
+function TransactionRow({ transaction, onSelect }: { transaction: TransactionEntry; onSelect: (id: string) => void }) {
+  const substates = transaction.transaction.V1.body.transaction.inputs;
   return (
-    <div className="tx-row">
-      <div className="tx-row-left">
-        <span className="tx-id mono" title={transaction.transaction_id}>
-          {truncate(transaction.transaction_id, 12, 10)}
-        </span>
+    <>
+      <div className="substate-row">
+        <div className="substate-left">
+          <span className="substate-id mono" title={transaction.transaction_id}>
+            Transaction ID: {truncate(transaction.transaction_id, 12, 10)}
+          </span>
+        </div>
+        <div className="substate-right">
+          <span className="timestamp">{formatTime(transaction.created_at)}</span>
+        </div>
       </div>
-      <div className="tx-row-right">
-        <span className="timestamp">{formatTime(transaction.created_at)}</span>
+      <p>
+        <b>Substates from the Transaction Inputs</b>
+      </p>
+      <div className="substate-list">
+        {substates?.length > 0
+          ? substates.map((s) => {
+              return (
+                <span key={s.substate_id} className="mono substate-id" onClick={() => onSelect(s.substate_id)}>
+                  <b>substate_id:</b> {s.substate_id}
+                </span>
+              );
+            })
+          : null}
       </div>
-    </div>
+      <hr />
+    </>
   );
 }
 

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -18,7 +18,7 @@ const NETWORKS: { label: string; value: Network }[] = [
 ];
 
 export function App() {
-  const { status, error, connect, disconnect, getSubstate, listSubstates } = useIndexer();
+  const { status, error, connect, disconnect, getSubstate, getClient } = useIndexer();
 
   // Connection form state
   const [url, setUrl] = useState(DEFAULT_URL);
@@ -34,25 +34,6 @@ export function App() {
   const [substates, setSubstates] = useState<SubstateEntry[]>([]);
   const [listLoading, setListLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
-
-  const loadSubstates = useCallback(async () => {
-    setListLoading(true);
-    setListError(null);
-    try {
-      const response = await listSubstates({ limit: 20 });
-      setSubstates(response.substates);
-    } catch (err) {
-      setListError(err instanceof Error ? err.message : "Failed to list substates");
-    } finally {
-      setListLoading(false);
-    }
-  }, [listSubstates]);
-
-  // Auto-load recent substates when connected
-  useEffect(() => {
-    if (status !== "connected") return;
-    void loadSubstates();
-  }, [loadSubstates, status]);
 
   const handleConnect = () => {
     void connect(url, network);
@@ -72,6 +53,10 @@ export function App() {
       setLookupLoading(false);
     }
   };
+
+  useEffect(() => {
+    getClient();
+  }, [getClient]);
 
   // ── Connect screen ──────────────────────────────────────────────────────────
   if (status !== "connected") {

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { Network, defaultIndexerUrl } from "@tari-project/ootle";
 import { useIndexer } from "./hooks/useIndexer";
 import type { SubstateEntry } from "./hooks/useIndexer";
@@ -18,7 +18,7 @@ const NETWORKS: { label: string; value: Network }[] = [
 ];
 
 export function App() {
-  const { status, error, connect, disconnect, getSubstate, getClient } = useIndexer();
+  const { status, error, connect, disconnect, getSubstate, getIndexerInfo } = useIndexer();
 
   // Connection form state
   const [url, setUrl] = useState(DEFAULT_URL);
@@ -30,8 +30,7 @@ export function App() {
   const [lookupError, setLookupError] = useState<string | null>(null);
   const [lookupLoading, setLookupLoading] = useState(false);
 
-  // Recent substates state
-  const [substates, setSubstates] = useState<SubstateEntry[]>([]);
+  const [info, setInfo] = useState<Record<string, unknown>>({});
   const [listLoading, setListLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
 
@@ -55,8 +54,18 @@ export function App() {
   };
 
   useEffect(() => {
-    getClient();
-  }, [getClient]);
+    if (status !== "connected") return;
+    setListLoading(true);
+    getIndexerInfo()
+      .then((r) => {
+        setInfo(r);
+        setListLoading(false);
+      })
+      .catch((e) => {
+        setListError(e instanceof Error ? e.message : "Failed to fetch info");
+        setListLoading(false);
+      });
+  }, [getIndexerInfo, status]);
 
   // ── Connect screen ──────────────────────────────────────────────────────────
   if (status !== "connected") {
@@ -182,25 +191,26 @@ export function App() {
         {/* Recent substates */}
         <section className="panel">
           <div className="panel-header">
-            <h2 className="panel-title">Recent Substates</h2>
-            <button className="btn-ghost small" onClick={() => void loadSubstates()} disabled={listLoading}>
+            <h2 className="panel-title">Indexer Info</h2>
+            <button className="btn-ghost small" disabled={listLoading}>
               {listLoading ? <Spinner /> : "Refresh"}
             </button>
           </div>
 
+          {Object.entries(info)?.length > 0
+            ? Object.entries(info).map(([k, v]) => (
+                // TEMP
+                <div key={k}>
+                  <p>
+                    <b>{k}</b>: <span>{v?.toString()}</span>
+                  </p>
+                </div>
+              ))
+            : null}
+
           {listError && (
             <div className="error-banner" role="alert">
               {listError}
-            </div>
-          )}
-
-          {substates.length === 0 && !listLoading && !listError && <p className="empty-state">No substates found.</p>}
-
-          {substates.length > 0 && (
-            <div className="substate-list">
-              {substates.map((s) => (
-                <SubstateRow key={s.substate_id} substate={s} onSelect={(id) => setLookupId(id)} />
-              ))}
             </div>
           )}
         </section>

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -7,8 +7,10 @@ import "./App.css";
 // Public Esmeralda testnet indexer — no local setup required.
 // Swap for http://localhost:18300 (with Network.LocalNet) when using a local indexer.
 const DEFAULT_NETWORK = Network.Esmeralda;
+console.debug(`DEFAULT_NETWORK`, DEFAULT_NETWORK);
+console.debug(`hi`);
 const DEFAULT_URL = defaultIndexerUrl(DEFAULT_NETWORK);
-
+console.debug(`DEFAULT_URL =`, DEFAULT_URL);
 const NETWORKS: { label: string; value: Network }[] = [
   { label: "Esmeralda testnet (public)", value: Network.Esmeralda },
   { label: "LocalNet", value: Network.LocalNet },

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -7,10 +7,8 @@ import "./App.css";
 // Public Esmeralda testnet indexer — no local setup required.
 // Swap for http://localhost:18300 (with Network.LocalNet) when using a local indexer.
 const DEFAULT_NETWORK = Network.Esmeralda;
-console.debug(`DEFAULT_NETWORK`, DEFAULT_NETWORK);
-console.debug(`hi`);
 const DEFAULT_URL = defaultIndexerUrl(DEFAULT_NETWORK);
-console.debug(`DEFAULT_URL =`, DEFAULT_URL);
+
 const NETWORKS: { label: string; value: Network }[] = [
   { label: "Esmeralda testnet (public)", value: Network.Esmeralda },
   { label: "LocalNet", value: Network.LocalNet },

--- a/examples/indexer-explorer/src/App.tsx
+++ b/examples/indexer-explorer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Network, defaultIndexerUrl } from "@tari-project/ootle";
 import type { TransactionEntry } from "@tari-project/ootle-indexer";
 import { useIndexer } from "./hooks/useIndexer";
@@ -54,21 +54,25 @@ export function App() {
     }
   };
 
-  useEffect(() => {
-    if (status !== "connected" || txList?.length > 0) return;
+  const handleTransactions = useCallback(() => {
     setListLoading(true);
-    getRecentTransactions().then(
-      (txs) => {
+    getRecentTransactions()
+      .then((txs) => {
         setTxList(txs);
-        setListLoading(false);
-      },
-      (err) => {
+      })
+      .catch((err) => {
         console.error(err);
         setListError(err instanceof Error ? err.message : "Failed to fetch recent transactions");
+      })
+      .finally(() => {
         setListLoading(false);
-      },
-    );
-  }, [getRecentTransactions, status, txList?.length]);
+      });
+  }, [getRecentTransactions]);
+
+  useEffect(() => {
+    if (status !== "connected" || txList?.length > 0) return;
+    handleTransactions();
+  }, [handleTransactions, status, txList?.length]);
 
   // ── Connect screen ──────────────────────────────────────────────────────────
   if (status !== "connected") {
@@ -195,7 +199,7 @@ export function App() {
         <section className="panel">
           <div className="panel-header">
             <h2 className="panel-title">Recent Transactions</h2>
-            <button className="btn-ghost small" disabled={listLoading}>
+            <button className="btn-ghost small" disabled={listLoading} onClick={handleTransactions}>
               {listLoading ? <Spinner /> : "Refresh"}
             </button>
           </div>

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -4,14 +4,6 @@ import { Network } from "@tari-project/ootle";
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected";
 
-export interface SubstateEntry {
-  substate_id: string;
-  module_name: string | null;
-  version: number;
-  template_address: string | null;
-  timestamp: string;
-}
-
 /**
  * Manages a read-only connection to an Ootle indexer.
  *
@@ -64,5 +56,11 @@ export function useIndexer() {
     return { ...networkInfo, ...connections };
   }, [client]);
 
-  return { status, provider, error, connect, disconnect, getSubstate, getIndexerInfo };
+  const getRecentTransactions = useCallback(
+    async () =>
+      (await provider?.listRecentTransactions({ limit: 10, last_id: null })?.then((r) => r.transactions)) ?? [],
+    [provider],
+  );
+
+  return { status, provider, error, connect, disconnect, getSubstate, getIndexerInfo, getRecentTransactions };
 }

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { ProviderBuilder, IndexerProvider } from "@tari-project/ootle-indexer";
+import { ProviderBuilder, IndexerProvider, IndexerClient } from "@tari-project/ootle-indexer";
 import { Network } from "@tari-project/ootle";
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected";
@@ -25,6 +25,7 @@ export interface SubstateEntry {
 export function useIndexer() {
   const [status, setStatus] = useState<ConnectionStatus>("disconnected");
   const [provider, setProvider] = useState<IndexerProvider | null>(null);
+  const [client, setClient] = useState<IndexerClient | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const connect = useCallback(async (url: string, network: Network) => {
@@ -33,6 +34,8 @@ export function useIndexer() {
     try {
       const p = await ProviderBuilder.new().withNetwork(network).withUrl(url.trim()).connect();
       setProvider(p);
+      const c = p?.getClient();
+      setClient(c);
       setStatus("connected");
     } catch (err) {
       setStatus("disconnected");
@@ -54,22 +57,12 @@ export function useIndexer() {
     [provider],
   );
 
-  const listSubstates = useCallback(
-    async (opts: { filterByType?: string; limit?: number } = {}) => {
-      if (!provider) throw new Error("Not connected");
-      return provider.listSubstates({
-        filterByType: opts.filterByType,
-        limit: opts.limit ?? 20,
-      });
-    },
-    [provider],
-  );
+  const getIndexerInfo = useCallback(async () => {
+    const networkInfo = await client?.networkInfo();
+    const connections = await client?.getConnections();
 
-  const getClient = useCallback(async () => {
-    const c = provider?.getClient();
-    const networkInfo = await c?.networkInfo();
-    console.debug(networkInfo);
-  }, [provider]);
+    return { ...networkInfo, ...connections };
+  }, [client]);
 
-  return { status, provider, error, connect, disconnect, getSubstate, listSubstates, getClient };
+  return { status, provider, error, connect, disconnect, getSubstate, getIndexerInfo };
 }

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -48,19 +48,15 @@ export function useIndexer() {
     },
     [provider],
   );
-
-  const getIndexerInfo = useCallback(async () => {
-    const networkInfo = await client?.networkInfo();
-    const connections = await client?.getConnections();
-
-    return { ...networkInfo, ...connections };
-  }, [client]);
+  //
+  // const getIndexerInfo = useCallback(async () => {
+  // }, []);
 
   const getRecentTransactions = useCallback(
     async () =>
-      (await provider?.listRecentTransactions({ limit: 10, last_id: null })?.then((r) => r.transactions)) ?? [],
+      (await provider?.listRecentTransactions({ limit: 5, last_id: null })?.then((r) => r.transactions)) ?? [],
     [provider],
   );
 
-  return { status, provider, error, connect, disconnect, getSubstate, getIndexerInfo, getRecentTransactions };
+  return { status, provider, error, connect, disconnect, getSubstate, getRecentTransactions };
 }

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -32,7 +32,6 @@ export function useIndexer() {
     setError(null);
     try {
       const p = await ProviderBuilder.new().withNetwork(network).withUrl(url.trim()).connect();
-      console.debug(`p =`, p);
       setProvider(p);
       setStatus("connected");
     } catch (err) {

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -32,6 +32,7 @@ export function useIndexer() {
     setError(null);
     try {
       const p = await ProviderBuilder.new().withNetwork(network).withUrl(url.trim()).connect();
+      console.debug(`p =`, p);
       setProvider(p);
       setStatus("connected");
     } catch (err) {

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -65,5 +65,11 @@ export function useIndexer() {
     [provider],
   );
 
-  return { status, provider, error, connect, disconnect, getSubstate, listSubstates };
+  const getClient = useCallback(async () => {
+    const c = provider?.getClient();
+    const networkInfo = await c?.networkInfo();
+    console.debug(networkInfo);
+  }, [provider]);
+
+  return { status, provider, error, connect, disconnect, getSubstate, listSubstates, getClient };
 }

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -11,13 +11,13 @@ type ConnectionStatus = "disconnected" | "connecting" | "connected";
  * verifies connectivity (fetches indexer identity) before resolving.
  *
  * Usage:
- *   const { status, connect, getSubstate, listSubstates } = useIndexer()
+ *   const { status, connect, getSubstate, listRecentTransactions } = useIndexer()
  *   await connect("http://localhost:18300", Network.LocalNet)
  */
 export function useIndexer() {
   const [status, setStatus] = useState<ConnectionStatus>("disconnected");
   const [provider, setProvider] = useState<IndexerProvider | null>(null);
-  const [client, setClient] = useState<IndexerClient | null>(null);
+  const [_client, setClient] = useState<IndexerClient | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const connect = useCallback(async (url: string, network: Network) => {

--- a/examples/indexer-explorer/src/hooks/useIndexer.ts
+++ b/examples/indexer-explorer/src/hooks/useIndexer.ts
@@ -48,9 +48,6 @@ export function useIndexer() {
     },
     [provider],
   );
-  //
-  // const getIndexerInfo = useCallback(async () => {
-  // }, []);
 
   const getRecentTransactions = useCallback(
     async () =>

--- a/examples/template-inspector/README.md
+++ b/examples/template-inspector/README.md
@@ -82,7 +82,7 @@ If the ABI has an unfamiliar shape, the raw JSON is shown as a fallback.
 
 | Service | URL |
 |---------|-----|
-| Esmeralda testnet indexer | `http://217.182.93.35:50124` |
+| Esmeralda testnet indexer | `https://ootle-indexer-a.tari.com` |
 
 To point at a local indexer instead, edit the URL in the top bar and press Enter.
 
@@ -91,10 +91,10 @@ To point at a local indexer instead, edit the URL in the top bar and press Enter
 ## Troubleshooting
 
 **No templates appear / "Connection error"**
-The public indexer may be temporarily unavailable. Wait a moment and click **Refresh**. If the error persists, check your network — requests to `http://` (non-HTTPS) addresses are blocked by some networks and browsers.
+The public indexer may be temporarily unavailable. Wait a moment and click **Refresh**. If the error persists, check your network connection.
 
 **CORS error in browser console**
-Some browser configurations block cross-origin HTTP requests to plain HTTP endpoints. Try a different browser, or run a local indexer at `http://localhost:12500` and enter that URL in the top bar.
+Some browser configurations block cross-origin requests. Try a different browser, or run a local indexer at `http://localhost:12500` and enter that URL in the top bar.
 
 **Template list loads but ABI shows raw JSON**
 The ABI for that template may use a type shape not yet handled by the viewer. The raw JSON view is the fallback — all the information is there, just not pretty-printed. This is expected for unusual template types.

--- a/examples/template-inspector/package.json
+++ b/examples/template-inspector/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@tari-project/ootle": "workspace:*",
     "@tari-project/ootle-indexer": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/template-inspector/src/App.tsx
+++ b/examples/template-inspector/src/App.tsx
@@ -1,6 +1,6 @@
+import type { TemplateMetadata } from "@tari-project/ootle-indexer";
 import { useState } from "react";
 import { useTemplates } from "./hooks/useTemplates";
-import type { TemplateListItem } from "./hooks/useTemplates";
 import "./App.css";
 
 export function App() {
@@ -22,7 +22,7 @@ export function App() {
 
   const filtered = templates.filter((t) => {
     const q = search.toLowerCase();
-    return t.template_address.toLowerCase().includes(q) || (t.name ?? "").toLowerCase().includes(q);
+    return t.address.toLowerCase().includes(q) || (t.name ?? "").toLowerCase().includes(q);
   });
 
   return (
@@ -94,10 +94,10 @@ export function App() {
           <div className="template-list">
             {filtered.map((t) => (
               <TemplateRow
-                key={t.template_address}
+                key={t.address}
                 template={t}
-                selected={selectedAddress === t.template_address}
-                onSelect={() => void selectTemplate(t.template_address)}
+                selected={selectedAddress === t.address}
+                onSelect={() => void selectTemplate(t.address)}
               />
             ))}
           </div>
@@ -149,15 +149,15 @@ function TemplateRow({
   selected,
   onSelect,
 }: {
-  template: TemplateListItem;
+  template: TemplateMetadata;
   selected: boolean;
   onSelect: () => void;
 }) {
   return (
     <button className={`template-row ${selected ? "selected" : ""}`} onClick={onSelect}>
       <span className="template-name">{template.name ?? "Unnamed"}</span>
-      <span className="template-addr mono" title={template.template_address}>
-        {truncate(template.template_address, 8, 6)}
+      <span className="template-addr mono" title={template.address}>
+        {truncate(template.address, 8, 6)}
       </span>
     </button>
   );

--- a/examples/template-inspector/src/hooks/useTemplates.ts
+++ b/examples/template-inspector/src/hooks/useTemplates.ts
@@ -1,13 +1,12 @@
 import { useState, useCallback, useEffect } from "react";
 import { IndexerClient } from "@tari-project/ootle-indexer";
+import type { TemplateMetadata } from "@tari-project/ootle-indexer";
+import { defaultIndexerUrl, Network } from "@tari-project/ootle";
 
-const ESME_INDEXER = "http://217.182.93.35:50124";
+const DEFAULT_NETWORK = Network.Esmeralda;
+const DEFAULT_URL = defaultIndexerUrl(DEFAULT_NETWORK);
 
-// Minimal shape we care about from ListTemplatesResponse
-export interface TemplateListItem {
-  template_address: string;
-  name?: string | null;
-}
+const ESME_INDEXER = DEFAULT_URL;
 
 export type LoadStatus = "idle" | "loading" | "ready" | "error";
 
@@ -15,7 +14,7 @@ export interface UseTemplates {
   indexerUrl: string;
   setIndexerUrl: (url: string) => void;
   loadStatus: LoadStatus;
-  templates: TemplateListItem[];
+  templates: TemplateMetadata[];
   loadError: string | null;
   reload: () => Promise<void>;
 
@@ -36,7 +35,7 @@ export interface UseTemplates {
 export function useTemplates(): UseTemplates {
   const [indexerUrl, setIndexerUrl] = useState(ESME_INDEXER);
   const [loadStatus, setLoadStatus] = useState<LoadStatus>("idle");
-  const [templates, setTemplates] = useState<TemplateListItem[]>([]);
+  const [templates, setTemplates] = useState<TemplateMetadata[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [selectedAddress, setSelectedAddress] = useState<string | null>(null);
@@ -49,7 +48,11 @@ export function useTemplates(): UseTemplates {
     setLoadError(null);
     try {
       const client = IndexerClient.usingFetchTransport(indexerUrl);
-      const raw = await client.getTransport().sendGet<{ templates?: TemplateListItem[] }>("templates", { limit: "50" });
+      await client.identityGet();
+      const raw = await client
+        .getTransport()
+        .sendGet<{ templates?: TemplateMetadata[] }>("templates/cached", { limit: "50" });
+
       setTemplates(raw.templates ?? []);
       setLoadStatus("ready");
     } catch (err) {

--- a/examples/template-inspector/src/hooks/useTemplates.ts
+++ b/examples/template-inspector/src/hooks/useTemplates.ts
@@ -1,12 +1,9 @@
-import { useState, useCallback, useEffect } from "react";
-import { IndexerClient } from "@tari-project/ootle-indexer";
+import { useCallback, useEffect, useState } from "react";
 import type { TemplateMetadata } from "@tari-project/ootle-indexer";
+import { IndexerClient } from "@tari-project/ootle-indexer";
 import { defaultIndexerUrl, Network } from "@tari-project/ootle";
 
-const DEFAULT_NETWORK = Network.Esmeralda;
-const DEFAULT_URL = defaultIndexerUrl(DEFAULT_NETWORK);
-
-const ESME_INDEXER = DEFAULT_URL;
+const ESME_INDEXER = defaultIndexerUrl(Network.Esmeralda);
 
 export type LoadStatus = "idle" | "loading" | "ready" | "error";
 

--- a/packages/ootle-indexer/src/event-stream.ts
+++ b/packages/ootle-indexer/src/event-stream.ts
@@ -27,7 +27,7 @@ export function parseSseChunk(buffer: string): { events: IndexerSseEvent[]; rema
     if (!block.trim()) continue;
 
     let type = "message";
-    let dataLines: string[] = [];
+    const dataLines: string[] = [];
 
     for (const line of block.split(/\n|\r\n/)) {
       if (line.startsWith("event:")) {
@@ -64,10 +64,7 @@ export function parseSseChunk(buffer: string): { events: IndexerSseEvent[]; rema
  *
  * Mirrors the `EventStream` / `into_stream()` pattern from the Rust ootle-rs crate.
  */
-export async function* openEventStream(
-  url: string,
-  signal: AbortSignal,
-): AsyncGenerator<IndexerSseEvent> {
+export async function* openEventStream(url: string, signal: AbortSignal): AsyncGenerator<IndexerSseEvent> {
   const RETRY_DELAY_MS = 5_000;
 
   while (!signal.aborted) {
@@ -114,7 +111,14 @@ export async function* openEventStream(
       console.warn("[ootle-indexer] SSE stream error, retrying in 5 s:", (err as Error).message);
       await new Promise<void>((resolve) => {
         const t = setTimeout(resolve, RETRY_DELAY_MS);
-        signal.addEventListener("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            resolve();
+          },
+          { once: true },
+        );
       });
     } finally {
       signal.removeEventListener("abort", onAbort);

--- a/packages/ootle-indexer/src/index.ts
+++ b/packages/ootle-indexer/src/index.ts
@@ -6,6 +6,8 @@ export type { IndexerProviderOptions } from "./indexer-provider";
 
 // Re-export from @tari-project/indexer-client so consumers don't need a direct dependency
 export { IndexerClient, transports } from "@tari-project/indexer-client";
+// Re-export from @tari-project/ootle-ts-binds so consumers don't need a direct dependency
+export type { TransactionEntry } from "@tari-project/ootle-ts-bindings";
 
 export { ProviderBuilder } from "./provider-builder";
 export { resolveWantInputs } from "./want-input";

--- a/packages/ootle-indexer/src/index.ts
+++ b/packages/ootle-indexer/src/index.ts
@@ -7,7 +7,7 @@ export type { IndexerProviderOptions } from "./indexer-provider";
 // Re-export from @tari-project/indexer-client so consumers don't need a direct dependency
 export { IndexerClient, transports } from "@tari-project/indexer-client";
 // Re-export from @tari-project/ootle-ts-binds so consumers don't need a direct dependency
-export type { TransactionEntry } from "@tari-project/ootle-ts-bindings";
+export type { TransactionEntry, TemplateMetadata } from "@tari-project/ootle-ts-bindings";
 
 export { ProviderBuilder } from "./provider-builder";
 export { resolveWantInputs } from "./want-input";

--- a/packages/ootle-indexer/src/indexer-provider.ts
+++ b/packages/ootle-indexer/src/indexer-provider.ts
@@ -26,8 +26,8 @@ export interface IndexerProviderOptions {
 }
 
 export class IndexerProvider implements Provider {
-  private client: IndexerClient;
-  private _network: Network;
+  private readonly client: IndexerClient;
+  private readonly _network: Network;
   private readonly _url: string;
   private _watcher: TransactionWatcher | null = null;
   readonly defaultTransactionTimeoutMs: number;

--- a/packages/ootle-indexer/src/indexer-provider.ts
+++ b/packages/ootle-indexer/src/indexer-provider.ts
@@ -7,12 +7,13 @@ import type {
   IndexerGetSubstateResponse,
   IndexerGetTransactionResultResponse,
   IndexerSubmitTransactionResponse,
+  ListRecentTransactionsRequest,
+  ListRecentTransactionsResponse,
   SubstateId,
   SubstateRequirement,
   TransactionEnvelope,
-  ListSubstateItem,
 } from "@tari-project/ootle-ts-bindings";
-import type { ListSubstatesRequest, ListSubstatesResponse, Provider } from "@tari-project/ootle";
+import type { Provider } from "@tari-project/ootle";
 import { Network } from "@tari-project/ootle";
 import { IndexerClient } from "@tari-project/indexer-client";
 import { PendingTransaction, TransactionWatcher } from "./tx-watcher";
@@ -135,25 +136,7 @@ export class IndexerProvider implements Provider {
     );
   }
 
-  public async listSubstates(params: ListSubstatesRequest): Promise<ListSubstatesResponse> {
-    // The external IndexerClient does not expose a listSubstates method.
-    // Use the transport directly to hit GET /substates with query filters.
-    const query: Record<string, unknown> = {};
-    if (params.filterByTemplate != null) query["filter_by_template"] = params.filterByTemplate;
-    if (params.filterByType != null) query["filter_by_type"] = params.filterByType;
-    if (params.limit != null) query["limit"] = params.limit;
-    if (params.offset != null) query["offset"] = params.offset;
-
-    const result = await this.client.getTransport().sendGet<{ substates: ListSubstateItem[] }>("substates", query);
-
-    return {
-      substates: result.substates.map((s) => ({
-        substate_id: s.substate_id,
-        module_name: s.module_name,
-        version: s.version,
-        template_address: s.template_address,
-        timestamp: s.timestamp,
-      })),
-    };
+  public async listRecentTransactions(params: ListRecentTransactionsRequest): Promise<ListRecentTransactionsResponse> {
+    return await this.client.listRecentTransactions(params);
   }
 }

--- a/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.ts
+++ b/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.ts
@@ -2,15 +2,13 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
-import { Signer, toHexStr } from "@tari-project/ootle";
-import { generateKeypair, hashUnsignedTransaction, schnorrSign } from "@tari-project/ootle-wasm";
+import { generateKeypair, generateOotleAddress, hashUnsignedTransaction, schnorrSign } from "@tari-project/ootle-wasm";
+import { Network, Signer, toHexStr } from "@tari-project/ootle";
 
 /**
  * A one-shot signer that generates a fresh throwaway keypair, signs once,
  * and exposes no way to reuse the key. Used for privacy-preserving transactions
- * where the sender wants no link between the transaction and their identity.
- *
- * Mirrors `EphemeralKeySigner` from the Rust ootle-rs crate.
+ * where the sender wants no link between the transaction and their identity.*
  *
  * @example
  * ```ts
@@ -21,25 +19,26 @@ import { generateKeypair, hashUnsignedTransaction, schnorrSign } from "@tari-pro
 export class EphemeralKeySigner implements Signer {
   private readonly secretKeyHex: Uint8Array;
   private readonly publicKeyHex: Uint8Array;
+  public address: string;
 
-  private constructor(secretKeyHex: Uint8Array, publicKeyHex: Uint8Array) {
+  private constructor(secretKeyHex: Uint8Array, publicKeyHex: Uint8Array, network: Network) {
     this.secretKeyHex = secretKeyHex;
     this.publicKeyHex = publicKeyHex;
+    const randomKeypair = generateKeypair();
+    this.address = generateOotleAddress(publicKeyHex, randomKeypair.public_key, network);
   }
 
   /**
    * Generates a fresh ephemeral keypair. The secret key exists only for the
    * lifetime of this object and is never persisted.
    */
-  public static generate(): EphemeralKeySigner {
+  public static generate(network = Network.Esmeralda): EphemeralKeySigner {
     const keypair = generateKeypair();
-    return new EphemeralKeySigner(keypair.secret_key, keypair.public_key);
+    return new EphemeralKeySigner(keypair.secret_key, keypair.public_key, network);
   }
 
   public async getAddress(): Promise<string> {
-    // Ephemeral signers have no persistent address — return the public key as-is.
-    // TODO - fix this when keys -> address is ready
-    return Promise.resolve(toHexStr(this.publicKeyHex));
+    return Promise.resolve(this.address);
   }
 
   public async getPublicKey(): Promise<Uint8Array> {

--- a/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.ts
+++ b/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.ts
@@ -8,7 +8,7 @@ import { Network, Signer, toHexStr } from "@tari-project/ootle";
 /**
  * A one-shot signer that generates a fresh throwaway keypair, signs once,
  * and exposes no way to reuse the key. Used for privacy-preserving transactions
- * where the sender wants no link between the transaction and their identity.*
+ * where the sender wants no link between the transaction and their identity.
  *
  * @example
  * ```ts
@@ -19,7 +19,7 @@ import { Network, Signer, toHexStr } from "@tari-project/ootle";
 export class EphemeralKeySigner implements Signer {
   private readonly secretKeyHex: Uint8Array;
   private readonly publicKeyHex: Uint8Array;
-  public address: string;
+  public readonly address: string;
 
   private constructor(secretKeyHex: Uint8Array, publicKeyHex: Uint8Array, network: Network) {
     this.secretKeyHex = secretKeyHex;

--- a/packages/ootle-secret-key-wallet/src/secret-key-wallet.ts
+++ b/packages/ootle-secret-key-wallet/src/secret-key-wallet.ts
@@ -2,32 +2,43 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
-import { Signer, toHexStr } from "@tari-project/ootle";
 import {
   generateKeypair,
+  generateOotleAddress,
+  generateOotleSecretKey,
   hashUnsignedTransaction,
+  ootlePublicKeyFromSecretKey,
   publicKeyFromSecretKey,
   schnorrSign,
 } from "@tari-project/ootle-wasm";
+import { Network, Signer, toHexStr } from "@tari-project/ootle";
 
 /**
  * A local signer that holds a secret key (and optional view-only key) in memory,
  * using the WASM module for transaction hashing and Schnorr signing.
- *
- * Mirrors `OotleSecretKey` / `PrivateKeyProvider` from the Rust ootle-rs crate.
- *
+ **
  * For production use, prefer `WalletDaemonSigner` so the secret key never lives
  * in JavaScript memory.
  */
 export class SecretKeyWallet implements Signer {
-  private readonly accountSecretHex: Uint8Array;
+  private readonly ownerSecretKey: Uint8Array;
+  private readonly ownerPublicKey: Uint8Array;
   private readonly viewOnlySecretHex: Uint8Array | null;
-  private readonly publicKeyHex: Uint8Array;
+  private readonly viewOnlyPublicKey: Uint8Array | null;
+  public network: Network;
 
-  private constructor(accountSecretHex: Uint8Array, viewOnlySecretHex: Uint8Array | null, publicKeyHex: Uint8Array) {
-    this.accountSecretHex = accountSecretHex;
-    this.viewOnlySecretHex = viewOnlySecretHex;
-    this.publicKeyHex = publicKeyHex;
+  private constructor(
+    ownerSecretKey: Uint8Array,
+    ownerPublicKey: Uint8Array,
+    network: Network,
+    viewOnlySecretHex?: Uint8Array | null,
+    viewOnlyPublicKey?: Uint8Array | null,
+  ) {
+    this.ownerSecretKey = ownerSecretKey;
+    this.ownerPublicKey = ownerPublicKey;
+    this.viewOnlySecretHex = viewOnlySecretHex ?? null;
+    this.viewOnlyPublicKey = viewOnlyPublicKey ?? null;
+    this.network = network;
   }
 
   /**
@@ -35,19 +46,23 @@ export class SecretKeyWallet implements Signer {
    * The view-only key is used for stealth/confidential output scanning.
    * Mirrors `OotleSecretKey { account_secret, view_only_secret }` from ootle-rs.
    */
-  public static randomWithViewKey(): SecretKeyWallet {
-    const accountKeypair = generateKeypair();
-    const viewKeypair = generateKeypair();
-    return new SecretKeyWallet(accountKeypair.secret_key, viewKeypair.secret_key, accountKeypair.public_key);
+  public static randomWithViewKey(network: Network): SecretKeyWallet {
+    const { owner_key, view_key } = generateOotleSecretKey();
+    const publicKeys = ootlePublicKeyFromSecretKey(owner_key, view_key);
+    return new SecretKeyWallet(owner_key, view_key, network, publicKeys.owner_key, publicKeys.view_key);
   }
 
   /**
    * Creates a wallet from an existing hex-encoded account secret key.
    * The public key is derived via `wasm.derivePublicKey`.
    */
-  public static fromSecretKey(accountSecretHex: Uint8Array, viewOnlySecretHex?: Uint8Array): SecretKeyWallet {
-    const publicKeyHex = publicKeyFromSecretKey(accountSecretHex);
-    return new SecretKeyWallet(accountSecretHex, viewOnlySecretHex ?? null, publicKeyHex);
+  public static fromSecretKey(
+    ownerSecretKey: Uint8Array,
+    network: Network,
+    viewOnlySecretHex?: Uint8Array,
+  ): SecretKeyWallet {
+    const ownerPublicKey = publicKeyFromSecretKey(ownerSecretKey);
+    return new SecretKeyWallet(ownerSecretKey, ownerPublicKey, network, viewOnlySecretHex ?? null);
   }
 
   /**
@@ -55,19 +70,24 @@ export class SecretKeyWallet implements Signer {
    * Use this overload if you already have both keys (e.g. from key storage).
    */
   public static fromKeypair(
-    accountSecretHex: Uint8Array,
-    publicKeyHex: Uint8Array,
+    ownerSecretKey: Uint8Array,
+    ownerPublicKey: Uint8Array,
+    network: Network,
     viewOnlySecretHex?: Uint8Array,
   ): SecretKeyWallet {
-    return new SecretKeyWallet(accountSecretHex, viewOnlySecretHex ?? null, publicKeyHex);
+    return new SecretKeyWallet(ownerSecretKey, ownerPublicKey, network, viewOnlySecretHex ?? null);
   }
 
   public async getAddress(): Promise<string> {
-    return Promise.resolve(toHexStr(this.publicKeyHex));
+    if (!this.viewOnlyPublicKey) {
+      throw new Error("View-only key not set. Call SecretKeyWallet.randomWithViewKey() first.");
+    }
+    const address = generateOotleAddress(this.ownerPublicKey, this.viewOnlyPublicKey, this.network);
+    return Promise.resolve(address);
   }
 
   public async getPublicKey(): Promise<Uint8Array> {
-    return Promise.resolve(this.publicKeyHex);
+    return Promise.resolve(this.ownerPublicKey);
   }
 
   /**
@@ -79,11 +99,11 @@ export class SecretKeyWallet implements Signer {
   }
 
   public async signTransaction(unsignedTx: UnsignedTransactionV1): Promise<TransactionSignature[]> {
-    const hashBytes = hashUnsignedTransaction(JSON.stringify(unsignedTx), this.publicKeyHex);
-    const sig = schnorrSign(this.accountSecretHex, hashBytes);
+    const hashBytes = hashUnsignedTransaction(JSON.stringify(unsignedTx), this.ownerPublicKey);
+    const sig = schnorrSign(this.ownerSecretKey, hashBytes);
     return Promise.resolve([
       {
-        public_key: toHexStr(this.publicKeyHex),
+        public_key: toHexStr(this.ownerPublicKey),
         signature: {
           public_nonce: toHexStr(sig.public_nonce),
           signature: toHexStr(sig.signature),

--- a/packages/ootle-secret-key-wallet/src/secret-key-wallet.ts
+++ b/packages/ootle-secret-key-wallet/src/secret-key-wallet.ts
@@ -3,7 +3,6 @@
 
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
 import {
-  generateKeypair,
   generateOotleAddress,
   generateOotleSecretKey,
   hashUnsignedTransaction,
@@ -16,7 +15,7 @@ import { Network, Signer, toHexStr } from "@tari-project/ootle";
 /**
  * A local signer that holds a secret key (and optional view-only key) in memory,
  * using the WASM module for transaction hashing and Schnorr signing.
- **
+ *
  * For production use, prefer `WalletDaemonSigner` so the secret key never lives
  * in JavaScript memory.
  */
@@ -25,7 +24,7 @@ export class SecretKeyWallet implements Signer {
   private readonly ownerPublicKey: Uint8Array;
   private readonly viewOnlySecretHex: Uint8Array | null;
   private readonly viewOnlyPublicKey: Uint8Array | null;
-  public network: Network;
+  public readonly network: Network;
 
   private constructor(
     ownerSecretKey: Uint8Array,
@@ -47,9 +46,9 @@ export class SecretKeyWallet implements Signer {
    * Mirrors `OotleSecretKey { account_secret, view_only_secret }` from ootle-rs.
    */
   public static randomWithViewKey(network: Network): SecretKeyWallet {
-    const { owner_key, view_key } = generateOotleSecretKey();
-    const publicKeys = ootlePublicKeyFromSecretKey(owner_key, view_key);
-    return new SecretKeyWallet(owner_key, view_key, network, publicKeys.owner_key, publicKeys.view_key);
+    const secretKeys = generateOotleSecretKey();
+    const pubKeys = ootlePublicKeyFromSecretKey(secretKeys.owner_key, secretKeys.view_key);
+    return new SecretKeyWallet(secretKeys.owner_key, pubKeys.owner_key, network, secretKeys.view_key, pubKeys.view_key);
   }
 
   /**

--- a/packages/ootle-wallet-daemon-signer/src/wallet-daemon-signer.ts
+++ b/packages/ootle-wallet-daemon-signer/src/wallet-daemon-signer.ts
@@ -2,8 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
-import { type Signer, fromHexStr } from "@tari-project/ootle";
 import { WalletDaemonClient } from "@tari-project/wallet_jrpc_client";
+import { type Signer, fromHexStr } from "@tari-project/ootle";
 
 export interface WalletDaemonSignerOptions {
   /** Base URL of the wallet daemon HTTP endpoint, e.g. "http://localhost:18103" */
@@ -24,7 +24,7 @@ export interface WalletDaemonSignerOptions {
  * environment usage where the wallet daemon is reachable.
  */
 export class WalletDaemonSigner implements Signer {
-  private client: WalletDaemonClient;
+  private readonly client: WalletDaemonClient;
   private _publicKey: Uint8Array | null = null;
   private _address: string | null = null;
 

--- a/packages/ootle/src/helpers/index.ts
+++ b/packages/ootle/src/helpers/index.ts
@@ -1,0 +1,3 @@
+export { toHexStr, fromHexStr } from "./hex";
+export { defaultIndexerUrl } from "./network";
+export { type ParsedWorkspaceKey, parseWorkspaceStringKey } from "./workspace";

--- a/packages/ootle/src/helpers/network.ts
+++ b/packages/ootle/src/helpers/network.ts
@@ -14,7 +14,7 @@ export function defaultIndexerUrl(network: Network): string {
     case Network.LocalNet:
       return "http://localhost:12500";
     case Network.Esmeralda:
-      return "http://217.182.93.35:50124";
+      return "https://ootle-indexer-a.tari.com";
     case Network.MainNet:
       throw new Error("No default indexer URL configured for MainNet");
     case Network.StageNet:

--- a/packages/ootle/src/index.ts
+++ b/packages/ootle/src/index.ts
@@ -19,8 +19,6 @@ export {
 export type {
   Amount,
   WatchOptions,
-  ListSubstatesRequest,
-  ListSubstatesResponse,
   TransactionOutcome,
   ToAccountAddress,
   UnsignedTransactionV1,

--- a/packages/ootle/src/provider.ts
+++ b/packages/ootle/src/provider.ts
@@ -10,9 +10,10 @@ import type {
   SubstateRequirement,
   SubstateId,
   GetTemplateDefinitionResponse,
+  ListRecentTransactionsRequest,
+  ListRecentTransactionsResponse,
 } from "@tari-project/ootle-ts-bindings";
 import type { Network } from "./network";
-import type { ListSubstatesRequest, ListSubstatesResponse } from "./types";
 
 /**
  * A Provider reads chain state and submits transactions. It has no signing capability.
@@ -46,6 +47,6 @@ export interface Provider {
    */
   resolveInputs(inputs: SubstateRequirement[]): Promise<SubstateRequirement[]>;
 
-  /** Lists substates with optional template/type filters. */
-  listSubstates(params: ListSubstatesRequest): Promise<ListSubstatesResponse>;
+  /** Lists recent transactions. */
+  listRecentTransactions(params: ListRecentTransactionsRequest): Promise<ListRecentTransactionsResponse>;
 }

--- a/packages/ootle/src/transaction.ts
+++ b/packages/ootle/src/transaction.ts
@@ -15,7 +15,7 @@ import type { Provider } from "./provider";
 import type { Signer } from "./signer";
 import type { WatchOptions } from "./types";
 import { borEncodeTransaction, generateKeypair, hashUnsignedTransaction, schnorrSign } from "@tari-project/ootle-wasm";
-import { toHexStr } from "./helpers/hex";
+import { toHexStr } from "./helpers";
 
 /**
  * Resolves unversioned inputs in the unsigned transaction by fetching their current

--- a/packages/ootle/src/types.ts
+++ b/packages/ootle/src/types.ts
@@ -57,20 +57,3 @@ export interface WatchOptions {
 export interface ToAccountAddress {
   toAccountAddress(): string;
 }
-
-export interface ListSubstatesRequest {
-  filterByTemplate?: string | null;
-  filterByType?: string | null;
-  limit?: number | null;
-  offset?: number | null;
-}
-
-export interface ListSubstatesResponse {
-  substates: Array<{
-    substate_id: string;
-    module_name: string | null;
-    version: number;
-    template_address: string | null;
-    timestamp: string;
-  }>;
-}

--- a/packages/ootle/src/wallet.ts
+++ b/packages/ootle/src/wallet.ts
@@ -2,8 +2,8 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
-import type { Signer } from "./signer";
 import type { WalletKeyProvider } from "./key-provider";
+import type { Signer } from "./signer";
 
 /**
  * The result of authorizing a transaction: a set of signatures from one signer.

--- a/packages/ootle/vite.config.js
+++ b/packages/ootle/vite.config.js
@@ -21,10 +21,11 @@ export default {
       formats: ["es"],
     },
     rolldownOptions: {
-      external: ["@tari-project/ootle-ts-bindings"],
+      external: ["@tari-project/ootle-ts-bindings", "@tari-project/ootle-wasm"],
       output: {
         globals: {
           "@tari-project/ootle-ts-bindings": "ootle-ts-bindings",
+          "@tari-project/ootle-wasm": "ootle-wasm",
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^1.2.1
       version: 1.2.1
     '@tari-project/ootle-ts-bindings':
-      specifier: ^1.29.3
-      version: 1.29.3
+      specifier: ^1.30.0
+      version: 1.30.0
     '@tari-project/ootle-wasm':
       specifier: ^0.3.0
       version: 0.3.0
@@ -254,7 +254,7 @@ importers:
     dependencies:
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.29.3
+        version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
         version: 0.3.0
@@ -294,7 +294,7 @@ importers:
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.29.3
+        version: 1.30.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -328,7 +328,7 @@ importers:
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.29.3
+        version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
         version: 0.3.0
@@ -365,7 +365,7 @@ importers:
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.29.3
+        version: 1.30.0
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
         version: 1.13.1
@@ -1784,8 +1784,8 @@ packages:
   '@tari-project/indexer-client@1.2.1':
     resolution: {integrity: sha512-245jDEjYLK9JkIBb4EAkVek/zFpSswK8tCTQ0vh1oa9F1d4/F8d8SftBxe8U7+nrLEuE8fW4efyg+3Z6DXYKxg==}
 
-  '@tari-project/ootle-ts-bindings@1.29.3':
-    resolution: {integrity: sha512-KA9lBLzlylOfzCOgqKQQl2EpRzFLijUly0BWBWtEFU+Dwppggety0JJmmqadkoRWx7vTomj2IqwrF6rp9QuWgQ==}
+  '@tari-project/ootle-ts-bindings@1.30.0':
+    resolution: {integrity: sha512-l1EFiB0dLcbfN9+IjZCUM8+j1+wAhTaz1jWDRgb8P1rostGo4y1jSlNH1F33oDG+z3lIJsMfiW9D3G9uLeVckg==}
 
   '@tari-project/ootle-wasm@0.3.0':
     resolution: {integrity: sha512-nQObQkIBweNTmteUTVG/5jcPSDJIQTlRpqTu5B+NRACTD1L4MkRR4IOjc6BX+iLzFM904msRZ3IdClnqLhvEzA==}
@@ -5147,9 +5147,9 @@ snapshots:
 
   '@tari-project/indexer-client@1.2.1':
     dependencies:
-      '@tari-project/ootle-ts-bindings': 1.29.3
+      '@tari-project/ootle-ts-bindings': 1.30.0
 
-  '@tari-project/ootle-ts-bindings@1.29.3':
+  '@tari-project/ootle-ts-bindings@1.30.0':
     dependencies:
       bech32: 2.0.0
 
@@ -5157,7 +5157,7 @@ snapshots:
 
   '@tari-project/wallet_jrpc_client@1.13.1':
     dependencies:
-      '@tari-project/ootle-ts-bindings': 1.29.3
+      '@tari-project/ootle-ts-bindings': 1.30.0
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^0.3.0
       version: 0.3.0
     '@tari-project/wallet_jrpc_client':
-      specifier: ^1.13.1
-      version: 1.13.1
+      specifier: ^1.14.0
+      version: 1.14.0
     '@types/node':
       specifier: ^25.5.0
       version: 25.5.0
@@ -368,7 +368,7 @@ importers:
         version: 1.30.0
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.13.1
+        version: 1.14.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -1790,8 +1790,8 @@ packages:
   '@tari-project/ootle-wasm@0.3.0':
     resolution: {integrity: sha512-nQObQkIBweNTmteUTVG/5jcPSDJIQTlRpqTu5B+NRACTD1L4MkRR4IOjc6BX+iLzFM904msRZ3IdClnqLhvEzA==}
 
-  '@tari-project/wallet_jrpc_client@1.13.1':
-    resolution: {integrity: sha512-2FxyM4BhoIBKlZQQk4XRLq45xliHyCe04GdQpFad0CzOSK0fFmCKilEyXuxHLwpHoQokrPgwvc4zo9+00OHUAA==}
+  '@tari-project/wallet_jrpc_client@1.14.0':
+    resolution: {integrity: sha512-7X8bsY26Qa4HYzJN9/S/95APUHyl/K0NPpo1+1MFQcYNckJfyBA79Sz8a7cBvKQiAXvS4d+qv2StV+dAcJVKRQ==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -5155,7 +5155,7 @@ snapshots:
 
   '@tari-project/ootle-wasm@0.3.0': {}
 
-  '@tari-project/wallet_jrpc_client@1.13.1':
+  '@tari-project/wallet_jrpc_client@1.14.0':
     dependencies:
       '@tari-project/ootle-ts-bindings': 1.30.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^1.29.3
       version: 1.29.3
     '@tari-project/ootle-wasm':
-      specifier: ^0.2.0
-      version: 0.2.0
+      specifier: ^0.3.0
+      version: 0.3.0
     '@tari-project/wallet_jrpc_client':
       specifier: ^1.13.1
       version: 1.13.1
@@ -257,7 +257,7 @@ importers:
         version: 1.29.3
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.3.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -331,7 +331,7 @@ importers:
         version: 1.29.3
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.3.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -523,11 +523,11 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -1787,8 +1787,8 @@ packages:
   '@tari-project/ootle-ts-bindings@1.29.3':
     resolution: {integrity: sha512-KA9lBLzlylOfzCOgqKQQl2EpRzFLijUly0BWBWtEFU+Dwppggety0JJmmqadkoRWx7vTomj2IqwrF6rp9QuWgQ==}
 
-  '@tari-project/ootle-wasm@0.2.0':
-    resolution: {integrity: sha512-5u7Ic0Ka5pfxy+kkiCznjj8D91tE15X3cR9nicsfmJ6CQcz7ybvJj/Ou/Z4zbC+pw4shQ8exM9rBrDimiTCXQA==}
+  '@tari-project/ootle-wasm@0.3.0':
+    resolution: {integrity: sha512-nQObQkIBweNTmteUTVG/5jcPSDJIQTlRpqTu5B+NRACTD1L4MkRR4IOjc6BX+iLzFM904msRZ3IdClnqLhvEzA==}
 
   '@tari-project/wallet_jrpc_client@1.13.1':
     resolution: {integrity: sha512-2FxyM4BhoIBKlZQQk4XRLq45xliHyCe04GdQpFad0CzOSK0fFmCKilEyXuxHLwpHoQokrPgwvc4zo9+00OHUAA==}
@@ -2081,8 +2081,8 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
-  baseline-browser-mapping@2.10.8:
-    resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
+  baseline-browser-mapping@2.10.9:
+    resolution: {integrity: sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2548,8 +2548,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  h3@1.15.8:
-    resolution: {integrity: sha512-iOH6Vl8mGd9nNfu9C0IZ+GuOAfJHcyf3VriQxWaSWIB76Fg4BnFuk4cxBxjmQSSxJS664+pgjP6e7VBnUzFfcg==}
+  h3@1.15.9:
+    resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3096,8 +3096,8 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mlly@1.8.1:
-    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4281,13 +4281,13 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.0':
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4615,7 +4615,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/runtime': 1.9.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -4714,8 +4714,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -5153,7 +5153,7 @@ snapshots:
     dependencies:
       bech32: 2.0.0
 
-  '@tari-project/ootle-wasm@0.2.0': {}
+  '@tari-project/ootle-wasm@0.3.0': {}
 
   '@tari-project/wallet_jrpc_client@1.13.1':
     dependencies:
@@ -5584,7 +5584,7 @@ snapshots:
 
   base-64@1.0.0: {}
 
-  baseline-browser-mapping@2.10.8: {}
+  baseline-browser-mapping@2.10.9: {}
 
   bcp-47-match@2.0.3: {}
 
@@ -5623,7 +5623,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.8
+      baseline-browser-mapping: 2.10.9
       caniuse-lite: 1.0.30001780
       electron-to-chromium: 1.5.321
       node-releases: 2.0.36
@@ -6087,7 +6087,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h3@1.15.8:
+  h3@1.15.9:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
@@ -6481,7 +6481,7 @@ snapshots:
 
   local-pkg@1.1.2:
     dependencies:
-      mlly: 1.8.1
+      mlly: 1.8.2
       pkg-types: 2.3.0
       quansync: 0.2.11
 
@@ -7012,7 +7012,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mlly@1.8.1:
+  mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
@@ -7194,7 +7194,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.1
+      mlly: 1.8.2
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -7812,7 +7812,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.8
+      h3: 1.15.9
       lru-cache: 11.2.7
       node-fetch-native: 1.6.7
       ofetch: 1.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
 
   examples/template-inspector:
     dependencies:
+      '@tari-project/ootle':
+        specifier: workspace:*
+        version: link:../../packages/ootle
       '@tari-project/ootle-indexer':
         specifier: workspace:*
         version: link:../../packages/ootle-indexer

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   "@eslint/js": ^10.0.1
   "@microsoft/api-extractor": ^7.57.7
   "@tari-project/indexer-client": ^1.2.1
-  "@tari-project/ootle-ts-bindings": ^1.29.3
+  "@tari-project/ootle-ts-bindings": ^1.30.0
   "@tari-project/ootle-wasm": ^0.3.0
   "@tari-project/wallet_jrpc_client": ^1.13.1
   "@types/node": ^25.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   "@tari-project/indexer-client": ^1.2.1
   "@tari-project/ootle-ts-bindings": ^1.30.0
   "@tari-project/ootle-wasm": ^0.3.0
-  "@tari-project/wallet_jrpc_client": ^1.13.1
+  "@tari-project/wallet_jrpc_client": ^1.14.0
   "@types/node": ^25.5.0
   eslint: ^10.0.3
   eslint-config-prettier: ^10.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@microsoft/api-extractor": ^7.57.7
   "@tari-project/indexer-client": ^1.2.1
   "@tari-project/ootle-ts-bindings": ^1.29.3
-  "@tari-project/ootle-wasm": ^0.2.0
+  "@tari-project/ootle-wasm": ^0.3.0
   "@tari-project/wallet_jrpc_client": ^1.13.1
   "@types/node": ^25.5.0
   eslint: ^10.0.3


### PR DESCRIPTION
Description
---

Fix and update the example apps (`indexer-explorer`, `template-inspector`, `connect-button`) to work with the latest upstream packages, and align the SDK with new WASM APIs for key generation
and address derivation.

**changes**:

- **Bump external deps**: `ootle-ts-bindings` 1.30, `ootle-wasm` 0.3, `wallet_jrpc_client` 1.14
- **Esmeralda indexer URL**: migrate from raw IP (`http://217.182.93.35:50124`) to `https://ootle-indexer-a.tari.com`
- **Replace `listSubstates` with `listRecentTransactions`**: the old substates endpoint is gone upstream; indexer-explorer now shows recent transactions with their substate inputs
- **`SecretKeyWallet`**: use `generateOotleSecretKey` / `ootlePublicKeyFromSecretKey` / `generateOotleAddress` from `ootle-wasm` 0.3 for proper Ootle address generation; all factory  
  methods now require a `Network` parameter
- **`EphemeralKeySigner`**: generate a proper Ootle address instead of returning the raw public key hex
- **template-inspector**: use `templates/cached` endpoint and upstream `TemplateMetadata` type instead of hand-rolled interfaces
- **Docs & READMEs**: updated to reflect all API changes

Motivation and Context
---

The example apps did not work.

How Has This Been Tested?
---

- `pnpm -r build` confirms all packages compile
- Examples manually verified against the public Esmeralda testnet indexer:

**connect btn example (walletd running locally):**


https://github.com/user-attachments/assets/e099d09f-5b63-4d9c-9ea5-64131a0edcf2


**indexer explorer example:**

https://github.com/user-attachments/assets/db201b01-91b7-4576-838b-980bd4bb715a

**template inspector example:**


https://github.com/user-attachments/assets/ed7ce9ac-d37b-41bd-a819-e09d6aba6645



Breaking Changes
---

- [ ] None
- [x] Please specify

**BREAKING CHANGE: SecretKeyWallet/EphemeralKeySigner APIs now require Network; Provider.listSubstates replaced by listRecentTransactions**

`SecretKeyWallet` factory methods (`randomWithViewKey`, `fromSecretKey`, `fromKeypair`) now require a `Network` parameter. `EphemeralKeySigner.generate()` accepts an optional `Network`
(defaults to Esmeralda). The `Provider` interface replaces `listSubstates()` with `listRecentTransactions()`. The `ListSubstatesRequest` / `ListSubstatesResponse` types are removed from `@tari-project/ootle`.


