### PR TITLE
feat(walletd-signer): automatic authentication support

### DIFF
--- a/examples/connect-button/src/App.tsx
+++ b/examples/connect-button/src/App.tsx
@@ -15,9 +15,8 @@ export function App() {
   const { status, address, publicKey, error, connect, disconnect } = useWalletDaemon();
 
   const [url, setUrl] = useState(DEFAULT_URL);
-  const [authToken, setAuthToken] = useState("");
 
-  const handleConnect = () => connect({ url: url.trim(), authToken: authToken.trim() });
+  const handleConnect = () => connect({ url: url.trim() });
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") handleConnect().catch((err) => console.error(err));
@@ -97,18 +96,6 @@ export function App() {
             spellCheck={false}
           />
 
-          <label className="field-label" htmlFor="token">
-            Auth Token
-          </label>
-          <input
-            id="token"
-            className="input"
-            type="password"
-            value={authToken}
-            onChange={(e) => setAuthToken(e.target.value)}
-            placeholder="Bearer …"
-            disabled={status === "connecting"}
-          />
         </div>
 
         {error && (
@@ -120,7 +107,7 @@ export function App() {
         <button
           className="btn-primary"
           onClick={() => void handleConnect()}
-          disabled={status === "connecting" || !url || !authToken}
+          disabled={status === "connecting" || !url}
         >
           {status === "connecting" ? (
             <>

--- a/examples/connect-button/src/hooks/useWalletDaemon.ts
+++ b/examples/connect-button/src/hooks/useWalletDaemon.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback } from "react";
-import { WalletDaemonSigner, type WalletDaemonSignerOptions } from "@tari-project/ootle-wallet-daemon-signer";
+import {
+  WalletDaemonSigner,
+  type WalletDaemonSignerOptions,
+  type AuthOptions,
+} from "@tari-project/ootle-wallet-daemon-signer";
 
 export type WalletStatus = "disconnected" | "connecting" | "connected";
 
@@ -11,8 +15,10 @@ export interface WalletState {
   error: string | null;
 }
 
+export type ConnectOptions = WalletDaemonSignerOptions & AuthOptions;
+
 export interface UseWalletDaemon extends WalletState {
-  connect: (options: WalletDaemonSignerOptions) => Promise<void>;
+  connect: (options: ConnectOptions) => Promise<void>;
   disconnect: () => void;
 }
 
@@ -30,18 +36,19 @@ const INITIAL: WalletState = {
  * The wallet daemon holds the user's secret key and returns the account
  * address + public key on connect. The key never touches JavaScript memory.
  *
+ * Authentication is handled automatically — if the daemon requires WebAuthn,
+ * the browser's passkey flow is triggered during `connect()`.
+ *
  * Usage:
  *   const { status, address, connect, disconnect } = useWalletDaemon()
- *   await connect({ url: "http://localhost:18103", authToken: "..." })
+ *   await connect({ url: "http://localhost:5100/json_rpc" })
  */
 export function useWalletDaemon(): UseWalletDaemon {
   const [state, setState] = useState<WalletState>(INITIAL);
 
-  const connect = useCallback(async (options: WalletDaemonSignerOptions) => {
+  const connect = useCallback(async (options: ConnectOptions) => {
     setState((s) => ({ ...s, status: "connecting", error: null }));
     try {
-      // WalletDaemonSigner.connect() reaches out to the daemon, fetches the
-      // default account's public key and address, and caches them.
       const signer = await WalletDaemonSigner.connect(options);
       const [address, publicKeyBytes] = await Promise.all([signer.getAddress(), signer.getPublicKey()]);
       const publicKey = Array.from(publicKeyBytes, (b) => b.toString(16).padStart(2, "0")).join("");

--- a/packages/ootle-wallet-daemon-signer/package.json
+++ b/packages/ootle-wallet-daemon-signer/package.json
@@ -21,16 +21,17 @@
   "dependencies": {
     "@tari-project/ootle": "workspace:",
     "@tari-project/ootle-ts-bindings": "catalog:",
-    "@tari-project/wallet_jrpc_client": "catalog:"
+    "@tari-project/wallet_jrpc_client": "catalog:",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
-    "@types/node": "catalog:",
     "@microsoft/api-extractor": "catalog:",
+    "@types/node": "catalog:",
     "typescript": "catalog:",
     "unplugin-dts": "catalog:",
-    "vitest": "catalog:",
     "vite": "catalog:",
     "vite-plugin-top-level-await": "catalog:",
-    "vite-plugin-wasm": "catalog:"
+    "vite-plugin-wasm": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/ootle-wallet-daemon-signer/src/auth.ts
+++ b/packages/ootle-wallet-daemon-signer/src/auth.ts
@@ -1,0 +1,152 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+import type { JrpcPermission } from "@tari-project/ootle-ts-bindings";
+import type { WalletDaemonClient } from "@tari-project/wallet_jrpc_client";
+import { Buffer } from "buffer";
+
+const DEFAULT_APP_NAME = "tari-wallet-sdk";
+const DEFAULT_PERMISSIONS: JrpcPermission[] = ["Admin"];
+
+export interface AuthOptions {
+  /** Permissions to request from the wallet daemon. Defaults to `["Admin"]`. */
+  permissions?: JrpcPermission[];
+  /** Application name used as the WebAuthn username/identifier. Defaults to `"tari-wallet-sdk"`. */
+  appName?: string;
+}
+
+/**
+ * Authenticate with the wallet daemon, automatically handling the configured
+ * auth method ("none" or "webauthn").
+ *
+ * For "none", a token is requested directly.
+ * For "webauthn", the browser's WebAuthn API is used to register or login,
+ * then the resulting credential is exchanged for a token.
+ *
+ * @returns The JWT auth token.
+ */
+export async function authenticate(client: WalletDaemonClient, options?: AuthOptions): Promise<string> {
+  const permissions = options?.permissions ?? DEFAULT_PERMISSIONS;
+  const appName = options?.appName ?? DEFAULT_APP_NAME;
+
+  const { method } = await client.authGetMethod();
+
+  switch (method) {
+    case "none":
+      return client.authRequest(permissions, "None");
+    case "webauthn":
+      return authenticateWebAuthn(client, appName, permissions);
+    default:
+      throw new Error(`Unsupported wallet daemon auth method: ${method}`);
+  }
+}
+
+async function authenticateWebAuthn(
+  client: WalletDaemonClient,
+  appName: string,
+  permissions: JrpcPermission[],
+): Promise<string> {
+  const { registered } = await client.webauthnAlreadyRegistered({ username: appName });
+
+  if (registered) {
+    return webauthnLogin(client, appName, permissions);
+  } else {
+    return webauthnRegister(client, appName, permissions);
+  }
+}
+
+async function webauthnLogin(
+  client: WalletDaemonClient,
+  appName: string,
+  permissions: JrpcPermission[],
+): Promise<string> {
+  const startResponse = await client.webauthnAuthStart({ username: appName });
+
+  if (!startResponse.challenge) {
+    throw new Error("WebAuthn auth start: missing challenge");
+  }
+
+  // The challenge object has shape { publicKey: { challenge, allowCredentials, ... } }
+  const challengeResponse = startResponse.challenge as Record<string, any>;
+  const publicKey = challengeResponse.publicKey;
+
+  const challenge = Buffer.from(publicKey.challenge, "base64");
+  const allowCredentials = (publicKey.allowCredentials ?? []).map((cred: Record<string, any>) => ({
+    id: Buffer.from(cred.id, "base64"),
+    type: cred.type,
+  }));
+
+  const credential = await navigator.credentials.get({
+    publicKey: {
+      challenge,
+      allowCredentials,
+      timeout: 60000,
+      userVerification: "required",
+    },
+  });
+
+  if (!credential) {
+    throw new Error("WebAuthn authentication was cancelled");
+  }
+
+  return client.authRequest(permissions, {
+    WebAuthN: {
+      session_id: startResponse.session_id,
+      credential,
+    },
+  });
+}
+
+async function webauthnRegister(
+  client: WalletDaemonClient,
+  appName: string,
+  permissions: JrpcPermission[],
+): Promise<string> {
+  const startResponse = await client.webauthnStartRegistration({ username: appName });
+
+  if (!startResponse.public_key) {
+    throw new Error("WebAuthn registration start: missing public_key");
+  }
+
+  // The public_key object is a serialized PublicKeyCredentialCreationOptions
+  const serverOptions = startResponse.public_key as Record<string, any>;
+  const challenge = Buffer.from(serverOptions.challenge, "base64");
+
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      rp: {
+        name: serverOptions.rp?.name ?? "Tari Wallet",
+        id: serverOptions.rp?.id ?? globalThis.location?.hostname,
+      },
+      user: {
+        id: Uint8Array.from(appName, (c) => c.charCodeAt(0)),
+        name: appName,
+        displayName: appName,
+      },
+      challenge,
+      pubKeyCredParams: serverOptions.pubKeyCredParams ?? [
+        { type: "public-key", alg: -8 }, // Ed25519
+        { type: "public-key", alg: -7 }, // ES256
+        { type: "public-key", alg: -257 }, // RS256
+      ],
+      timeout: 60000,
+      excludeCredentials: [],
+      attestation: "none",
+      authenticatorSelection: {
+        userVerification: "required",
+      },
+    },
+  });
+
+  if (!credential) {
+    throw new Error("WebAuthn registration was cancelled");
+  }
+
+  const { token } = await client.webauthnFinishRegistration({
+    session_id: startResponse.session_id,
+    credential,
+    requested_permissions: permissions,
+  });
+
+  return token;
+}

--- a/packages/ootle-wallet-daemon-signer/src/auth.ts
+++ b/packages/ootle-wallet-daemon-signer/src/auth.ts
@@ -8,6 +8,21 @@ import { Buffer } from "buffer";
 const DEFAULT_APP_NAME = "tari-wallet-sdk";
 const DEFAULT_PERMISSIONS: JrpcPermission[] = ["Admin"];
 
+/** Shape of the challenge object returned by `webauthn.auth_start`. */
+interface WebAuthnAuthChallenge {
+  publicKey: {
+    challenge: string;
+    allowCredentials?: { id: string; type: PublicKeyCredentialType }[];
+  };
+}
+
+/** Shape of the public_key object returned by `webauthn.reg_start`. */
+interface WebAuthnPublicKeyOptions {
+  challenge: string;
+  rp?: { name?: string; id?: string };
+  pubKeyCredParams?: PublicKeyCredentialParameters[];
+}
+
 export interface AuthOptions {
   /** Permissions to request from the wallet daemon. Defaults to `["Admin"]`. */
   permissions?: JrpcPermission[];
@@ -66,12 +81,14 @@ async function webauthnLogin(
     throw new Error("WebAuthn auth start: missing challenge");
   }
 
-  // The challenge object has shape { publicKey: { challenge, allowCredentials, ... } }
-  const challengeResponse = startResponse.challenge as Record<string, any>;
-  const publicKey = challengeResponse.publicKey;
+  const challengeResponse = startResponse.challenge as WebAuthnAuthChallenge;
+  if (!challengeResponse.publicKey?.challenge) {
+    throw new Error("WebAuthn auth start: malformed challenge response");
+  }
+  const { publicKey } = challengeResponse;
 
   const challenge = Buffer.from(publicKey.challenge, "base64");
-  const allowCredentials = (publicKey.allowCredentials ?? []).map((cred: Record<string, any>) => ({
+  const allowCredentials = (publicKey.allowCredentials ?? []).map((cred) => ({
     id: Buffer.from(cred.id, "base64"),
     type: cred.type,
   }));
@@ -108,8 +125,10 @@ async function webauthnRegister(
     throw new Error("WebAuthn registration start: missing public_key");
   }
 
-  // The public_key object is a serialized PublicKeyCredentialCreationOptions
-  const serverOptions = startResponse.public_key as Record<string, any>;
+  const serverOptions = startResponse.public_key as WebAuthnPublicKeyOptions;
+  if (!serverOptions.challenge) {
+    throw new Error("WebAuthn registration start: malformed public_key response");
+  }
   const challenge = Buffer.from(serverOptions.challenge, "base64");
 
   const credential = await navigator.credentials.create({

--- a/packages/ootle-wallet-daemon-signer/src/index.ts
+++ b/packages/ootle-wallet-daemon-signer/src/index.ts
@@ -3,6 +3,8 @@
 
 export { WalletDaemonSigner } from "./wallet-daemon-signer";
 export type { WalletDaemonSignerOptions } from "./wallet-daemon-signer";
+export { authenticate } from "./auth";
+export type { AuthOptions } from "./auth";
 
 // Re-export from @tari-project/wallet_jrpc_client so consumers don't need a direct dependency
 export { WalletDaemonClient } from "@tari-project/wallet_jrpc_client";

--- a/packages/ootle-wallet-daemon-signer/src/wallet-daemon-signer.ts
+++ b/packages/ootle-wallet-daemon-signer/src/wallet-daemon-signer.ts
@@ -4,15 +4,17 @@
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
 import { WalletDaemonClient } from "@tari-project/wallet_jrpc_client";
 import { type Signer, fromHexStr } from "@tari-project/ootle";
+import { authenticate, type AuthOptions } from "./auth";
 
 export interface WalletDaemonSignerOptions {
   /** Base URL of the wallet daemon HTTP endpoint, e.g. "http://localhost:18103" */
   url: string;
   /**
    * Token used to authenticate JRPC calls to the wallet daemon.
-   * Obtain via the wallet daemon's auth flow before constructing this signer.
+   * If omitted, {@link WalletDaemonSigner.connect} will automatically authenticate
+   * using the daemon's configured auth method (none or WebAuthn).
    */
-  authToken: string;
+  authToken?: string;
 }
 
 /**
@@ -33,19 +35,36 @@ export class WalletDaemonSigner implements Signer {
   }
 
   /**
-   * Creates a new signer without verifying connectivity.
-   * Prefer `connect()` for eager validation.
+   * Creates a new signer with the given auth token, without verifying connectivity.
+   * Prefer `connect()` for eager validation and automatic authentication.
    */
-  public static new(options: WalletDaemonSignerOptions): WalletDaemonSigner {
+  public static new(options: WalletDaemonSignerOptions & { authToken: string }): WalletDaemonSigner {
     const client = WalletDaemonClient.usingFetchTransport(options.url);
     client.setToken(options.authToken);
     return new WalletDaemonSigner(client);
   }
 
-  /** Connect to the daemon and cache the public key / address. */
-  public static async connect(options: WalletDaemonSignerOptions): Promise<WalletDaemonSigner> {
-    const signer = WalletDaemonSigner.new(options);
-    await signer?.fetchAccountInfo();
+  /**
+   * Connect to the daemon and cache the public key / address.
+   *
+   * If no `authToken` is provided, automatically authenticates using the daemon's
+   * configured auth method. For WebAuthn, this triggers the browser's passkey
+   * registration or login flow.
+   */
+  public static async connect(options: WalletDaemonSignerOptions & AuthOptions): Promise<WalletDaemonSigner> {
+    const client = WalletDaemonClient.usingFetchTransport(options.url);
+
+    if (options.authToken) {
+      client.setToken(options.authToken);
+    } else {
+      const token = await authenticate(client, options);
+      client.setToken(token);
+    }
+
+    client.setReauthenticationEnabled(true);
+
+    const signer = new WalletDaemonSigner(client);
+    await signer.fetchAccountInfo();
     return signer;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
         version: 1.14.0
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -2084,6 +2087,9 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.9:
     resolution: {integrity: sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==}
     engines: {node: '>=6.0.0'}
@@ -2120,6 +2126,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
@@ -2642,6 +2651,9 @@ packages:
 
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5587,6 +5599,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.9: {}
 
   bcp-47-match@2.0.3: {}
@@ -5631,6 +5645,11 @@ snapshots:
       electron-to-chromium: 1.5.321
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   camelcase@8.0.0: {}
 
@@ -6314,6 +6333,8 @@ snapshots:
   i18next@23.16.8:
     dependencies:
       '@babel/runtime': 7.29.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Add automatic authentication to `WalletDaemonSigner` — supports both `none` and `webauthn` auth methods
- `authToken` is now optional in `WalletDaemonSignerOptions`; when omitted, `connect()` authenticates automatically using the daemon's configured method
- For WebAuthn, the browser's passkey registration/login flow is triggered transparently
- Enables automatic token refresh on 401 errors via `setReauthenticationEnabled(true)`
- Remove manual auth token input from the connect-button example — connection now only requires the daemon URL

## Test plan
- [ ] Start wallet daemon with `--auth none` and verify connect-button example connects without prompting for a token
- [ ] Start wallet daemon with `--auth webauthn` and verify the browser passkey flow is triggered on connect
- [ ] Verify WebAuthn registration flow works for first-time users
- [ ] Verify WebAuthn login flow works for returning users
- [ ] Verify automatic token refresh works when a token expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)