### PR TITLE
fix(ci): publish only the real packages and enforce workspace versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle.ts",
-  "version": "0.14.6",
+  "version": "0.1.0",
   "description": "TypeScript SDK for building on the Tari Ootle network",
   "homepage": "https://github.com/tari-project/ootle.ts#readme",
   "bugs": {
@@ -10,10 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/tari-project/ootle.ts.git"
   },
-  "private": false,
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "type": "module",
   "keywords": [],
   "author": "The Tari Community",
@@ -38,6 +35,8 @@
     "docs:dev": "pnpm --filter ootle-docs dev",
     "lint": "pnpm -r lint",
     "knip": "knip",
+    "version:check": "./scripts/check_versions.sh",
+    "version:set": "./scripts/set_package_versions.sh",
     "test": "pnpm -r test",
     "test:watch": "pnpm --filter @tari-project/ootle vitest"
   },

--- a/packages/ootle-indexer/package.json
+++ b/packages/ootle-indexer/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tari-project/ootle-indexer",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ootle-secret-key-wallet/package.json
+++ b/packages/ootle-secret-key-wallet/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tari-project/ootle-secret-key-wallet",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ootle-wallet-daemon-signer/package.json
+++ b/packages/ootle-wallet-daemon-signer/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tari-project/ootle-wallet-daemon-signer",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ootle/package.json
+++ b/packages/ootle/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tari-project/ootle",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -2,45 +2,40 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-echo "Finding all package.json files and extracting versions..."
-
-declare -a versions
+# Verify every publishable package under packages/ inherits the workspace version.
+#
+# The root package.json `version` is the single source of truth (the "workspace
+# version"). Every packages/*/package.json must match it. Bump it everywhere with
+# ./scripts/set_package_versions.sh (or `pnpm version:set <version>`).
 
 gitroot=$(git rev-parse --show-toplevel)
-pushd "${gitroot}/packages" > /dev/null
-# Find all package.json files, excluding node_modules, and extract the version
+
+workspace_version=$(jq -r '.version' "${gitroot}/package.json")
+if [[ -z "$workspace_version" || "$workspace_version" == "null" ]]; then
+    echo "❌ ::error::Could not find 'version' field in the root package.json (the workspace version)."
+    exit 1
+fi
+echo "Workspace version (root package.json): $workspace_version"
+
+mismatch=false
 while IFS= read -r file; do
     version=$(jq -r '.version' "$file")
     if [[ -z "$version" || "$version" == "null" ]]; then
-        echo "::error::Could not find 'version' field in $file"
+        echo "❌ ::error::Could not find 'version' field in $file"
         exit 1
     fi
-    echo "Found version '$version' in $file"
-    versions+=("$version")
-done < <(find . -name 'package.json' -not -path '*/node_modules/*')
-
-if [ ${#versions[@]} -eq 0 ]; then
-    echo "Error: No package.json files with a 'version' field were found."
-    exit 1
-fi
-
-reference_version=${versions[0]}
-echo "Reference version: $reference_version"
-
-all_same=true
-for version in "${versions[@]}"; do
-    if [ "$version" != "$reference_version" ]; then
-        echo "Error: Mismatched version found! '$version' does not match '$reference_version'."
-        all_same=false
-        break
+    if [[ "$version" != "$workspace_version" ]]; then
+        echo "❌ ::error::$file is at '$version' but the workspace version is '$workspace_version'."
+        mismatch=true
+    else
+        echo "  ✓ $file @ $version"
     fi
-done
+done < <(find "${gitroot}/packages" -name 'package.json' -not -path '*/node_modules/*')
 
-if [ "$all_same" = false ]; then
-    echo "❌ ::error::All package.json versions are NOT the same. Please unify them."
+if [ "$mismatch" = true ]; then
+    echo "❌ ::error::One or more packages do not inherit the workspace version '$workspace_version'."
+    echo "   Run ./scripts/set_package_versions.sh ${workspace_version} (or 'pnpm version:set ${workspace_version}') to sync."
     exit 1
-else
-    echo "✅ All package.json versions are consistent: $reference_version"
 fi
 
-popd > /dev/null
+echo "✅ All packages inherit the workspace version: $workspace_version"

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -10,6 +10,11 @@ IFS=$'\n\t'
 
 gitroot=$(git rev-parse --show-toplevel)
 
+if [[ ! -d "${gitroot}/packages" ]]; then
+    echo "❌ ::error::Expected workspace directory '${gitroot}/packages' does not exist."
+    exit 1
+fi
+
 workspace_version=$(jq -r '.version' "${gitroot}/package.json")
 if [[ -z "$workspace_version" || "$workspace_version" == "null" ]]; then
     echo "❌ ::error::Could not find 'version' field in the root package.json (the workspace version)."
@@ -18,7 +23,11 @@ fi
 echo "Workspace version (root package.json): $workspace_version"
 
 mismatch=false
+checked_any=false
+# Match only each package's own manifest (packages/<pkg>/package.json) via -mindepth/-maxdepth,
+# never nested package.json files in dist/, build output, or test fixtures.
 while IFS= read -r file; do
+    checked_any=true
     version=$(jq -r '.version' "$file")
     if [[ -z "$version" || "$version" == "null" ]]; then
         echo "❌ ::error::Could not find 'version' field in $file"
@@ -30,7 +39,12 @@ while IFS= read -r file; do
     else
         echo "  ✓ $file @ $version"
     fi
-done < <(find "${gitroot}/packages" -name 'package.json' -not -path '*/node_modules/*')
+done < <(find "${gitroot}/packages" -mindepth 2 -maxdepth 2 -name 'package.json' -not -path '*/node_modules/*')
+
+if [[ "$checked_any" == "false" ]]; then
+    echo "❌ ::error::No package.json files found under ${gitroot}/packages — nothing was checked."
+    exit 1
+fi
 
 if [ "$mismatch" = true ]; then
     echo "❌ ::error::One or more packages do not inherit the workspace version '$workspace_version'."

--- a/scripts/set_package_versions.sh
+++ b/scripts/set_package_versions.sh
@@ -16,6 +16,11 @@ fi
 
 gitroot=$(git rev-parse --show-toplevel)
 
+if [[ ! -d "${gitroot}/packages" ]]; then
+    echo "::error::Expected workspace directory '${gitroot}/packages' does not exist."
+    exit 1
+fi
+
 VERSION="${1:-$(jq -r '.version' "${gitroot}/package.json")}"
 if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
     echo "::error::No version supplied and the root package.json has no 'version' field."
@@ -32,10 +37,19 @@ set_version() {
 # Root package.json is the source of truth — set it first (idempotent when inheriting).
 set_version "${gitroot}/package.json"
 
-# Propagate to every publishable package (same scope as check_versions.sh).
+# Propagate to every publishable package (same scope as check_versions.sh) — match only
+# each package's own manifest via -mindepth/-maxdepth, never nested package.json files in
+# dist/, build output, or test fixtures.
+updated_any=false
 while IFS= read -r package_json; do
+    updated_any=true
     set_version "$package_json"
-done < <(find "${gitroot}/packages" -name 'package.json' -not -path '*/node_modules/*')
+done < <(find "${gitroot}/packages" -mindepth 2 -maxdepth 2 -name 'package.json' -not -path '*/node_modules/*')
+
+if [[ "$updated_any" == "false" ]]; then
+    echo "::error::No package.json files found under ${gitroot}/packages to update."
+    exit 1
+fi
 
 pushd "${gitroot}" > /dev/null
 pnpm install

--- a/scripts/set_package_versions.sh
+++ b/scripts/set_package_versions.sh
@@ -1,34 +1,44 @@
 #!/bin/bash
 set -euo pipefail
+IFS=$'\n\t'
 
-# This script sets the package versions in all package.json files for the workspace.
+# Set the workspace version and propagate it to every publishable package so they all
+# inherit it. The root package.json is the single source of truth.
+#
+# Usage: ./scripts/set_package_versions.sh [version]
+#   <version>  bump the whole workspace (root + all packages/*) to this version
+#   (no arg)   re-sync packages/* to the current root (workspace) version
 
-# Usage: ./scripts/set_package_versions.sh <version>
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <version>"
+if [ "$#" -gt 1 ]; then
+    echo "Usage: $0 [version]   (defaults to the current root/workspace version)"
     exit 1
 fi
 
 gitroot=$(git rev-parse --show-toplevel)
 
-VERSION=$1
-# Find all package.json files in the workspace
-pushd "${gitroot}/packages" > /dev/null
-find . -depth -maxdepth 2 -name 'package.json' | while read -r package_json; do
-    # Update the version in the package.json file
-    jq --arg version "$VERSION" '.version = $version' "$package_json" > "$package_json.tmp" && mv "$package_json.tmp" "$package_json"
-    echo "Updated version in $package_json to $VERSION"
-done
-popd > /dev/null
+VERSION="${1:-$(jq -r '.version' "${gitroot}/package.json")}"
+if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+    echo "::error::No version supplied and the root package.json has no 'version' field."
+    exit 1
+fi
+echo "Workspace version: $VERSION"
+
+set_version() {
+    local file="$1"
+    jq --arg version "$VERSION" '.version = $version' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    echo "  ↑ ${file#"$gitroot/"} -> $VERSION"
+}
+
+# Root package.json is the source of truth — set it first (idempotent when inheriting).
+set_version "${gitroot}/package.json"
+
+# Propagate to every publishable package (same scope as check_versions.sh).
+while IFS= read -r package_json; do
+    set_version "$package_json"
+done < <(find "${gitroot}/packages" -name 'package.json' -not -path '*/node_modules/*')
 
 pushd "${gitroot}" > /dev/null
-# Update the version in the root package.json
-jq --arg version "$VERSION" '.version = $version' package.json > package.json.tmp && mv package.json.tmp package.json
-echo "Updated root package.json version to $VERSION"
-
 pnpm install
-
-echo "Running check_versions script to verify versions..."
+echo "Verifying versions..."
 ./scripts/check_versions.sh
 popd > /dev/null
-


### PR DESCRIPTION
## Description

Fixes the npm publish setup so CI publishes only the four real packages, and makes versioning robust.

**Root cause of the publish/version mess:** the monorepo root `@tari-project/ootle.ts` was being published (that's where the stray `0.14.6` npm release came from), and `check_versions.sh` only compared the `packages/*` manifests to each other — it never looked at the root, so the root silently drifted from the `0.1.0` packages.

## Changes

- **Root `@tari-project/ootle.ts` → `private: true`** so CI never (re)publishes the monorepo root. (`0.14.6` is already on npm; it just won't get new versions.)
- **`publishConfig.access: "public"`** added to the four publishable packages, so the scoped publish is public without relying on a `--access public` CLI flag.
- **Root `package.json` version is now the single workspace-version source of truth.** `check_versions.sh` reads it and asserts every `packages/*` inherits it — and now **fails on drift** (the case it previously missed).
- **`set_package_versions.sh`** defaults to the current root version when called with no arg (re-sync) and shares the check's file scope. Added `pnpm version:check` / `pnpm version:set`.
- **Realigned the root version `0.14.6 → 0.1.0`.**

## How to release going forward

Bump in one place: `pnpm version:set 0.1.1` (writes root + all packages, runs install, self-verifies). The publish workflow's version-gate then publishes the four packages when the version isn't yet on npm; the private root is skipped.

## Testing

- `./scripts/check_versions.sh` ✅ passes (`0.1.0` across root + all packages).
- Negative test: drifting the root version makes the check **fail** and name the mismatched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)