### PR TITLE
fix(ootle-secret-key-wallet): externalize @tari-project/ootle-wasm

### DIFF
--- a/packages/ootle-secret-key-wallet/vite.config.js
+++ b/packages/ootle-secret-key-wallet/vite.config.js
@@ -21,11 +21,12 @@ export default {
       formats: ["es"],
     },
     rolldownOptions: {
-      external: ["@tari-project/ootle-ts-bindings", "@tari-project/ootle"],
+      external: ["@tari-project/ootle-ts-bindings", "@tari-project/ootle", "@tari-project/ootle-wasm"],
       output: {
         globals: {
           "@tari-project/ootle-ts-bindings": "ootle-ts-bindings",
           "@tari-project/ootle": "ootle",
+          "@tari-project/ootle-wasm": "ootle-wasm",
         },
       },
     },


### PR DESCRIPTION
## Summary
- `packages/ootle-secret-key-wallet/vite.config.js`'s `rolldownOptions.external` array externalizes `@tari-project/ootle` but not `@tari-project/ootle-wasm` — unlike `packages/ootle/vite.config.js`, which correctly externalizes both `@tari-project/ootle-ts-bindings` and `@tari-project/ootle-wasm`.
- As a result, the published `dist/index.js` bundles the entire wasm module (wasm-bindgen glue + binary) directly inline (~1.5MB, containing its own `WebAssembly.instantiate`/`fetch` calls) instead of importing the shared `@tari-project/ootle-wasm` module.
- Any real app using both `@tari-project/ootle` (for `WasmStealthCrypto`/`StealthTransfer`) and this package (`SecretKeyWallet`, the actual signer) — which is every real wallet built on this SDK — ends up with **two fully separate `WebAssembly.Instance` objects** compiled from the same binary, each with its own isolated linear memory.
- This produced an intermittent `"JSON deserialization failed: data did not match any variant of untagged enum TransactionInput"` when signing stealth transfers specifically, via `SecretKeyWallet.signTransaction` → `addTransactionSigner`. Plain (non-stealth) signing was largely unaffected, matching what I observed live: the same account/key signed regular sends reliably but failed intermittently on stealth transfers.

## Fix
One-line addition to the `external` array (+ matching `output.globals` entry), matching `packages/ootle`'s own config.

Verified in a downstream build (a Chrome extension bundling both packages together): the shrunk-from-1.5MB-to-~4KB output no longer contains any `WebAssembly.instantiate` calls of its own, `__wbindgen_start` now appears exactly once in the final bundled output (previously twice), and the intermittent signing failure stopped reproducing after this + the sibling fix in #[to be linked].

## Context
Found and isolated while debugging shield/unshield support in a separate wallet extension — full investigation, including why the failure only showed up for stealth transfers specifically and how this was isolated from several other candidate causes, is in tari-project/ootle.ts#117.

## Test plan
- [x] `pnpm --filter @tari-project/ootle-secret-key-wallet run build` — bundle size drops from ~1.5MB to ~4KB, zero `WebAssembly.instantiate` in the output
- [x] Verified live against a real testnet account: shield (revealed → stealth) transactions that previously failed intermittently now succeed reliably