### PR TITLE
fix(ootle): include covenant_claims in signed stealth statement

### DIFF
--- a/packages/ootle/src/stealth/statements.ts
+++ b/packages/ootle/src/stealth/statements.ts
@@ -288,15 +288,9 @@ export class StealthTransferStatement {
     // structural debug `toJSON()` keeps the shorter `inputs`/`outputs` keys — it is not
     // the signed wire form.)
     //
-    // `covenant_claims` (TIP-0006, added to the protocol's `StealthTransferStatement` struct
-    // after this SDK's own snapshot) is a required field on the current wire struct -- omitting
-    // it entirely, as this used to, makes the WHOLE transaction fail server-side deserialization
-    // with a generic "did not match any variant of untagged enum TransactionInput" (the missing-
-    // field error on this deeply-nested struct isn't surfaced directly; it just fails every
-    // variant of the untagged wrapper enum). This builder never spends an input gated by a
-    // `Script` spend condition, so an empty array is always the correct value here — see
-    // tari-project/tari-ootle PR #2260's own description: "only the engine test tooling sets"
-    // a Script condition today, wallet/SDK population of claims is explicitly out of scope there.
+    // `covenant_claims` (TIP-0006) is non-optional on the binding type but `serde(default)` /
+    // `cbor(default)` on the wire struct, so emitting it leaves the signing hash unchanged.
+    // Always empty here: this builder never spends an input gated by a `Script` spend condition.
     let s = `{"inputs_statement":${inputsFragment},"outputs_statement":${outputsFragment},"covenant_claims":[]`;
     if (this.balanceProof !== undefined) {
       s += `,"balance_proof":${JSON.stringify(this.balanceProof.toJSON())}`;

--- a/packages/ootle/src/stealth/statements.ts
+++ b/packages/ootle/src/stealth/statements.ts
@@ -282,12 +282,22 @@ export class StealthTransferStatement {
     const outputsFragment = this.outputsStatement.statementJson; // raw WASM canonical string, carried verbatim
     assertJsonObject(inputsFragment, "inputs_statement");
     assertJsonObject(outputsFragment, "outputs_statement");
-    // Top-level keys are `inputs_statement` / `outputs_statement` / `balance_proof`,
-    // verified against the ootle-wasm@0.32 engine: `validateStealthTransfer` rejects an
-    // envelope keyed `inputs`/`outputs` with "missing field `inputs_statement`". (The
+    // Top-level keys are `inputs_statement` / `outputs_statement` / `balance_proof` /
+    // `covenant_claims`, verified against the ootle-wasm@0.32 engine: `validateStealthTransfer`
+    // rejects an envelope keyed `inputs`/`outputs` with "missing field `inputs_statement`". (The
     // structural debug `toJSON()` keeps the shorter `inputs`/`outputs` keys — it is not
     // the signed wire form.)
-    let s = `{"inputs_statement":${inputsFragment},"outputs_statement":${outputsFragment}`;
+    //
+    // `covenant_claims` (TIP-0006, added to the protocol's `StealthTransferStatement` struct
+    // after this SDK's own snapshot) is a required field on the current wire struct -- omitting
+    // it entirely, as this used to, makes the WHOLE transaction fail server-side deserialization
+    // with a generic "did not match any variant of untagged enum TransactionInput" (the missing-
+    // field error on this deeply-nested struct isn't surfaced directly; it just fails every
+    // variant of the untagged wrapper enum). This builder never spends an input gated by a
+    // `Script` spend condition, so an empty array is always the correct value here — see
+    // tari-project/tari-ootle PR #2260's own description: "only the engine test tooling sets"
+    // a Script condition today, wallet/SDK population of claims is explicitly out of scope there.
+    let s = `{"inputs_statement":${inputsFragment},"outputs_statement":${outputsFragment},"covenant_claims":[]`;
     if (this.balanceProof !== undefined) {
       s += `,"balance_proof":${JSON.stringify(this.balanceProof.toJSON())}`;
     }

--- a/packages/ootle/src/stealth/statements.ts
+++ b/packages/ootle/src/stealth/statements.ts
@@ -282,8 +282,8 @@ export class StealthTransferStatement {
     const outputsFragment = this.outputsStatement.statementJson; // raw WASM canonical string, carried verbatim
     assertJsonObject(inputsFragment, "inputs_statement");
     assertJsonObject(outputsFragment, "outputs_statement");
-    // Top-level keys are `inputs_statement` / `outputs_statement` / `balance_proof` /
-    // `covenant_claims`, verified against the ootle-wasm@0.32 engine: `validateStealthTransfer`
+    // Top-level keys are `inputs_statement` / `outputs_statement` / `covenant_claims` /
+    // `balance_proof`, verified against the ootle-wasm@0.37 engine: `validateStealthTransfer`
     // rejects an envelope keyed `inputs`/`outputs` with "missing field `inputs_statement`". (The
     // structural debug `toJSON()` keeps the shorter `inputs`/`outputs` keys — it is not
     // the signed wire form.)

--- a/packages/ootle/src/stealth/types.test.ts
+++ b/packages/ootle/src/stealth/types.test.ts
@@ -307,7 +307,7 @@ describe("StealthTransferStatement", () => {
     expect(compact).toContain(`"inputs_statement":${inputsWire}`);
     expect(compact).toContain(`"outputs_statement":${outputsBig}`);
     // And the assembled envelope is exactly the concatenation we expect.
-    expect(compact).toBe(`{"inputs_statement":${inputsWire},"outputs_statement":${outputsBig}}`);
+    expect(compact).toBe(`{"inputs_statement":${inputsWire},"outputs_statement":${outputsBig},"covenant_claims":[]}`);
     // Sanity: a naive JSON.parse round-trip WOULD have corrupted the u64 (proves the
     // byte-exact path is necessary, not theoretical).
     expect(String(JSON.parse(compact).outputs_statement.outputs[0].amount)).not.toBe(bigU64);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^1.30.0
       version: 1.30.0
     '@tari-project/ootle-wasm':
-      specifier: ^0.32.0
-      version: 0.32.0
+      specifier: ^0.37.0
+      version: 0.37.0
     '@tari-project/wallet_jrpc_client':
       specifier: ^1.14.0
       version: 1.14.0
@@ -263,7 +263,7 @@ importers:
         version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.32.0
+        version: 0.37.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -297,7 +297,7 @@ importers:
         version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.32.0
+        version: 0.37.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -383,7 +383,7 @@ importers:
         version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.32.0
+        version: 0.37.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -457,7 +457,7 @@ importers:
         version: 1.30.0
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.32.0
+        version: 0.37.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -2069,8 +2069,8 @@ packages:
   '@tari-project/ootle-ts-bindings@1.30.0':
     resolution: {integrity: sha512-l1EFiB0dLcbfN9+IjZCUM8+j1+wAhTaz1jWDRgb8P1rostGo4y1jSlNH1F33oDG+z3lIJsMfiW9D3G9uLeVckg==}
 
-  '@tari-project/ootle-wasm@0.32.0':
-    resolution: {integrity: sha512-ytGBwzCSdrR4sW+1t/Af5WnrftlQZlWNNlYKY6yOSNkZNMj3OiqPEiCzm136XnyhLUu95gNfHlIIqRou2JKoOg==}
+  '@tari-project/ootle-wasm@0.37.0':
+    resolution: {integrity: sha512-LyjIvJPyQ5shMzhwCM1lWijG+Nyf6OciqwT61c6VkLmq6SCr7dxLQ4+9Mn30c4pWPJm4n8wYddyF+hR4ZjFIFg==}
 
   '@tari-project/wallet_jrpc_client@1.14.0':
     resolution: {integrity: sha512-7X8bsY26Qa4HYzJN9/S/95APUHyl/K0NPpo1+1MFQcYNckJfyBA79Sz8a7cBvKQiAXvS4d+qv2StV+dAcJVKRQ==}
@@ -5523,7 +5523,7 @@ snapshots:
     dependencies:
       bech32: 2.0.0
 
-  '@tari-project/ootle-wasm@0.32.0': {}
+  '@tari-project/ootle-wasm@0.37.0': {}
 
   '@tari-project/wallet_jrpc_client@1.14.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@microsoft/api-extractor": ^7.57.7
   "@tari-project/indexer-client": ^1.2.1
   "@tari-project/ootle-ts-bindings": ^1.30.0
-  "@tari-project/ootle-wasm": ^0.32.0
+  "@tari-project/ootle-wasm": ^0.37.0
   "@tari-project/wallet_jrpc_client": ^1.14.0
   "@types/node": ^25.5.0
   eslint: ^10.0.3


### PR DESCRIPTION
## Summary
`StealthTransferStatement.toCompactJson()` never emitted a `covenant_claims` field. The protocol's `StealthTransferStatement` wire struct gained this field in tari-project/tari-ootle#2260 (merged 2026-06-19), after this SDK's 2026-06-01 snapshot — and it's required, not optional, on the current wire struct.

A missing required field this deep in the structure doesn't surface its own deserialization error — it just fails every variant of the engine's `#[serde(untagged)] enum TransactionInput` (`crates/ootle_wasm/core/src/transaction.rs`), producing the generic `"data did not match any variant of untagged enum TransactionInput"` for the *whole* transaction, with nothing pointing at the actual missing field.

An empty array is always correct here: this builder never spends an input gated by a `Script` spend condition (the only case `covenant_claims` is for) — see tari-ootle PR #2260's own description: "wallet/SDK population of claims is explicitly out of scope" today.

Also bumps the `ootle-wasm` catalog pin from `^0.32.0` to `^0.37.0`. Diffing the two installed `.d.ts` files showed `createStealthOutputWitness`'s internal JSON wrapper key renamed `spend_condition` → `auth` (with a new `SpendAuthorization` type) between those versions — same JS function signature either version, only the internal behavior differs. A downstream app that resolves `@tari-project/ootle-wasm` to a newer version directly (likely, since 0.32.0 is many releases behind) can end up with this package's `WasmStealthCrypto` silently building stealth outputs in the stale pre-rename shape, unless dependency resolution happens to collapse both to the same copy.

## Test plan
- [x] `pnpm --filter @tari-project/ootle run test` — 198/198 real tests pass (the vitest suites reported as "failed" locally are all a pre-existing Windows/`vite-plugin-wasm` loader incompatibility unrelated to this change — they fail at import time before any assertion runs, same failure with or without this diff)
- [x] Updated the one test with a hardcoded full-string expectation of `toCompactJson()`'s output to include `covenant_claims`
- [x] Verified live against a real testnet account, alongside the sibling fix in #118: shield transactions that previously failed with this exact error now build, sign, and submit successfully

## Context
Full investigation (including two other candidate causes ruled out before finding this one) is in tari-project/ootle.ts#117.