### PR TITLE
fix(builder)!: copy on adopt and resume workspace ids past occupied slots

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -14,8 +14,6 @@ const config: KnipConfig = {
   },
   // pnpm scripts that knip's binary scanner misreads as missing CLIs.
   ignoreBinaries: ["commitlint", "info", "build"],
-  // Invoked via `pnpm exec` and editor integrations, never imported.
-  ignoreDependencies: ["prettier"],
   ignoreExportsUsedInFile: true,
   workspaces: {
     // Reusable test fixtures pre-staged for future tests — flagged as unused today.

--- a/packages/ootle/src/builder.adopt.test.ts
+++ b/packages/ootle/src/builder.adopt.test.ts
@@ -1,0 +1,176 @@
+//   Copyright 2024 The Tari Project
+//   SPDX-License-Identifier: BSD-3-Clause
+
+// Tests for `TransactionBuilder.withUnsignedTransaction` — the "adopt an existing
+// transaction and keep building" path.
+//
+// Two invariants are pinned here, both of which the adopt path used to break while
+// `buildUnsignedTransaction` upheld them a few lines away:
+//
+//  1. COPY-ON-ADOPT. The builder must not alias the caller's arrays. The documented
+//     manual co-signing flow ships `JSON.stringify(unsigned)` across a process
+//     boundary; if a later builder call mutates the object the caller already
+//     serialized or signed, the two sides disagree and submission fails with the
+//     opaque engine error "Transaction has one or more invalid signature(s)".
+//
+//  2. NON-COLLIDING WORKSPACE SLOTS. Workspace ids are positional slots in the
+//     engine's workspace, not names. Adopting a transaction whose instructions
+//     already occupy slots and then restarting allocation at 0 hands out a live
+//     slot again: the second write clobbers it, and the pre-existing instruction
+//     reading that slot silently consumes the wrong bucket.
+
+import { describe, expect, it } from "vitest";
+import type { Instruction, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
+import { TransactionBuilder } from "./builder";
+import { FaucetInvokeBuilder } from "./builtin-templates";
+import { TEST_ACCOUNT_ADDRESS, TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS } from "./test/fixtures";
+
+const TEMPLATE_ADDRESS = "template_" + "ab".repeat(32);
+
+/** Every workspace slot written by `instructions` (`saveVar` / `allocateAddress` targets). */
+function writtenSlots(tx: UnsignedTransactionV1): number[] {
+  const slots: number[] = [];
+  for (const instruction of [...tx.fee_instructions, ...tx.instructions] as Instruction[]) {
+    if (typeof instruction !== "object" || instruction === null) continue;
+    if ("PutLastInstructionOutputOnWorkspace" in instruction) {
+      slots.push(instruction.PutLastInstructionOutputOnWorkspace.key);
+    } else if ("AllocateAddress" in instruction) {
+      slots.push(instruction.AllocateAddress.workspace_id);
+    }
+  }
+  return slots;
+}
+
+describe("withUnsignedTransaction — copy on adopt", () => {
+  it("does not mutate the adopted transaction's instructions", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK)
+      .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
+      .buildUnsignedTransaction();
+    const before = [...adopted.instructions];
+
+    TransactionBuilder.new(TEST_NETWORK).withUnsignedTransaction(adopted).dropAllProofsInWorkspace();
+
+    expect(adopted.instructions).toEqual(before);
+  });
+
+  it("does not mutate the adopted transaction's blobs", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    expect(adopted.blobs).toEqual([]);
+
+    TransactionBuilder.new(TEST_NETWORK).withUnsignedTransaction(adopted).publishTemplate("QUJD");
+
+    expect(adopted.blobs).toEqual([]);
+  });
+
+  it("does not mutate the adopted transaction's fee_instructions", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const before = [...adopted.fee_instructions];
+
+    TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1_000n);
+
+    expect(adopted.fee_instructions).toEqual(before);
+  });
+
+  it("does not mutate the adopted transaction's inputs", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const before = [...adopted.inputs];
+
+    TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .withInputs([{ substate_id: TEST_ACCOUNT_ADDRESS, version: null }]);
+
+    expect(adopted.inputs).toEqual(before);
+  });
+
+  it("keeps a serialized snapshot of the adopted transaction valid (the co-signing flow)", () => {
+    // The failure this guards: a co-signer serializes `adopted`, the local builder keeps
+    // building, and the two sides now hash different transactions.
+    const adopted = TransactionBuilder.new(TEST_NETWORK)
+      .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
+      .buildUnsignedTransaction();
+    const snapshot = JSON.stringify(adopted);
+
+    TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("bucket")
+      .publishTemplate("QUJD")
+      .buildUnsignedTransaction();
+
+    expect(JSON.stringify(adopted)).toBe(snapshot);
+  });
+});
+
+describe("withUnsignedTransaction — workspace slot allocation", () => {
+  it("does not re-issue a workspace slot the adopted transaction already occupies", () => {
+    // The faucet builder emits `PutLastInstructionOutputOnWorkspace { key: 0 }`.
+    const adopted = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+      .takeMaxFaucetFunds(TEST_ACCOUNT_ADDRESS)
+      .build();
+    expect(writtenSlots(adopted)).toEqual([0]);
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .callMethod({ componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "noop" }, [])
+      .saveVar("bucket")
+      .buildUnsignedTransaction();
+
+    const slots = writtenSlots(out);
+    expect(new Set(slots).size, `duplicate workspace slots: ${slots.join(", ")}`).toBe(slots.length);
+  });
+
+  it("resumes allocation past the highest occupied slot, including fee instructions", () => {
+    // Hand-build a transaction occupying slots 0 and 5, one of them in fee_instructions,
+    // so the seed cannot be derived from `instructions` alone or from a simple count.
+    const adopted: UnsignedTransactionV1 = {
+      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      fee_instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 5 } }],
+      instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 0 } }],
+    };
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("next")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out)).toEqual([5, 0, 6]);
+  });
+
+  it("counts AllocateAddress workspace ids as occupied", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK)
+      .allocateAddress("Component", "addr")
+      .buildUnsignedTransaction();
+    expect(writtenSlots(adopted)).toEqual([0]);
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("bucket")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out)).toEqual([0, 1]);
+  });
+
+  it("still starts at 0 when the adopted transaction occupies no slots", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK)
+      .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
+      .buildUnsignedTransaction();
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("bucket")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out)).toEqual([0]);
+  });
+
+  it("still clears the name→id mapping, so adopted names are not resolvable", () => {
+    // Unchanged behaviour: names are not recoverable from the wire form, only slots are.
+    const builder = TransactionBuilder.new(TEST_NETWORK)
+      .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
+      .saveVar("a");
+    builder.withUnsignedTransaction(TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction());
+
+    expect(() => builder.resolveWorkspaceOffsetId("a")).toThrow('No workspace variable named "a" has been defined');
+  });
+});

--- a/packages/ootle/src/builder.adopt.test.ts
+++ b/packages/ootle/src/builder.adopt.test.ts
@@ -18,6 +18,11 @@
 //     already occupy slots and then restarting allocation at 0 hands out a live
 //     slot again: the second write clobbers it, and the pre-existing instruction
 //     reading that slot silently consumes the wrong bucket.
+//
+// Slot accounting mirrors the Rust builder (`crates/transaction/src/builder`):
+// `Instruction::allocated_workspace_id` defines which instructions claim a slot, and
+// the fee instructions form a SEPARATE scope from the main ones — the engine drops the
+// whole workspace between the two runs, so their slot numbering is independent.
 
 import { describe, expect, it } from "vitest";
 import type { Instruction, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
@@ -27,13 +32,21 @@ import { TEST_ACCOUNT_ADDRESS, TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS } from
 
 const TEMPLATE_ADDRESS = "template_" + "ab".repeat(32);
 
-/** Every workspace slot written by `instructions` (`saveVar` / `allocateAddress` targets). */
-function writtenSlots(tx: UnsignedTransactionV1): number[] {
+/**
+ * Every workspace slot ALLOCATED by `instructions`, in order.
+ *
+ * Deliberately re-implements `Instruction::allocated_workspace_id` rather than importing
+ * the builder's copy, so a change to the production helper cannot silently agree with
+ * itself here.
+ */
+function writtenSlots(instructions: Instruction[]): number[] {
   const slots: number[] = [];
-  for (const instruction of [...tx.fee_instructions, ...tx.instructions] as Instruction[]) {
+  for (const instruction of instructions) {
     if (typeof instruction !== "object" || instruction === null) continue;
     if ("PutLastInstructionOutputOnWorkspace" in instruction) {
       slots.push(instruction.PutLastInstructionOutputOnWorkspace.key);
+    } else if ("TakeFromBucket" in instruction) {
+      slots.push(instruction.TakeFromBucket.output_bucket);
     } else if ("AllocateAddress" in instruction) {
       slots.push(instruction.AllocateAddress.workspace_id);
     }
@@ -108,7 +121,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
     const adopted = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
       .takeMaxFaucetFunds(TEST_ACCOUNT_ADDRESS)
       .build();
-    expect(writtenSlots(adopted)).toEqual([0]);
+    expect(writtenSlots(adopted.instructions)).toEqual([0]);
 
     const out = TransactionBuilder.new(TEST_NETWORK)
       .withUnsignedTransaction(adopted)
@@ -116,17 +129,19 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
       .saveVar("bucket")
       .buildUnsignedTransaction();
 
-    const slots = writtenSlots(out);
+    const slots = writtenSlots(out.instructions);
     expect(new Set(slots).size, `duplicate workspace slots: ${slots.join(", ")}`).toBe(slots.length);
   });
 
-  it("resumes allocation past the highest occupied slot, including fee instructions", () => {
-    // Hand-build a transaction occupying slots 0 and 5, one of them in fee_instructions,
-    // so the seed cannot be derived from `instructions` alone or from a simple count.
+  it("resumes allocation past the highest occupied slot in the MAIN scope", () => {
+    // Slots 3 and 1 occupied out of order, so the seed has to come from the max rather
+    // than from a count or from the last instruction.
     const adopted: UnsignedTransactionV1 = {
       ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
-      fee_instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 5 } }],
-      instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 0 } }],
+      instructions: [
+        { PutLastInstructionOutputOnWorkspace: { key: 3 } },
+        { PutLastInstructionOutputOnWorkspace: { key: 1 } },
+      ],
     };
 
     const out = TransactionBuilder.new(TEST_NETWORK)
@@ -134,21 +149,87 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
       .saveVar("next")
       .buildUnsignedTransaction();
 
-    expect(writtenSlots(out)).toEqual([5, 0, 6]);
+    expect(writtenSlots(out.instructions)).toEqual([3, 1, 4]);
+  });
+
+  it("keeps the fee scope independent of the main scope", () => {
+    // The engine drops the workspace between the fee run and the main run, so a slot
+    // claimed by a fee instruction must NOT push the main counter along (and vice versa).
+    // Rust models this as a separate fee-instruction builder with its own WorkspaceIds.
+    const adopted: UnsignedTransactionV1 = {
+      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      fee_instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 5 } }],
+      instructions: [],
+    };
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("next")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out.fee_instructions)).toEqual([5]);
+    // Main scope is untouched by the fee slot: allocation still starts at 0.
+    expect(writtenSlots(out.instructions)).toEqual([0]);
+  });
+
+  it("counts TakeFromBucket output_bucket as an allocation", () => {
+    // The third allocator in Rust's `allocated_workspace_id`; `input_bucket` only reads.
+    const adopted: UnsignedTransactionV1 = {
+      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      instructions: [
+        {
+          TakeFromBucket: {
+            input_bucket: { id: 0, offset: null },
+            amount: "100",
+            output_bucket: 4,
+          },
+        } as Instruction,
+      ],
+    };
+
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withUnsignedTransaction(adopted)
+      .saveVar("next")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out.instructions)).toEqual([4, 5]);
+  });
+
+  it("addInstruction accounts for a pre-built instruction's slot (as Rust's add_instruction does)", () => {
+    // Not an adopt path: slots that arrive through the public escape hatches must be
+    // accounted for too, or the next saveVar collides with them.
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .addInstruction({ PutLastInstructionOutputOnWorkspace: { key: 2 } })
+      .saveVar("next")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out.instructions)).toEqual([2, 3]);
+  });
+
+  it("withInstructions accounts for pre-built slots too", () => {
+    const out = TransactionBuilder.new(TEST_NETWORK)
+      .withInstructions([
+        { PutLastInstructionOutputOnWorkspace: { key: 0 } },
+        { AllocateAddress: { allocatable_type: "Component", workspace_id: 7 } },
+      ])
+      .saveVar("next")
+      .buildUnsignedTransaction();
+
+    expect(writtenSlots(out.instructions)).toEqual([0, 7, 8]);
   });
 
   it("counts AllocateAddress workspace ids as occupied", () => {
     const adopted = TransactionBuilder.new(TEST_NETWORK)
       .allocateAddress("Component", "addr")
       .buildUnsignedTransaction();
-    expect(writtenSlots(adopted)).toEqual([0]);
+    expect(writtenSlots(adopted.instructions)).toEqual([0]);
 
     const out = TransactionBuilder.new(TEST_NETWORK)
       .withUnsignedTransaction(adopted)
       .saveVar("bucket")
       .buildUnsignedTransaction();
 
-    expect(writtenSlots(out)).toEqual([0, 1]);
+    expect(writtenSlots(out.instructions)).toEqual([0, 1]);
   });
 
   it("still starts at 0 when the adopted transaction occupies no slots", () => {
@@ -161,7 +242,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
       .saveVar("bucket")
       .buildUnsignedTransaction();
 
-    expect(writtenSlots(out)).toEqual([0]);
+    expect(writtenSlots(out.instructions)).toEqual([0]);
   });
 
   it("still clears the name→id mapping, so adopted names are not resolvable", () => {

--- a/packages/ootle/src/builder.ts
+++ b/packages/ootle/src/builder.ts
@@ -30,6 +30,43 @@ function templateAddressToHash32(address: PublishedTemplateAddress): string {
   return address.startsWith(prefix) ? address.slice(prefix.length) : address;
 }
 
+/**
+ * The workspace slot an instruction **writes**, or `null` if it writes none.
+ *
+ * Only two instructions claim a slot: `PutLastInstructionOutputOnWorkspace` (what
+ * `saveVar` emits) and `AllocateAddress`. Everything else that mentions a workspace id
+ * — `CallMethod`'s `{ Workspace }` call target, `{ Workspace: WorkspaceOffsetId }` args,
+ * `CreateAccount.bucket_workspace_id` — *reads* an existing slot.
+ */
+function workspaceSlotWrittenBy(instruction: Instruction): number | null {
+  if (typeof instruction !== "object" || instruction === null) {
+    return null;
+  }
+  if ("PutLastInstructionOutputOnWorkspace" in instruction) {
+    return instruction.PutLastInstructionOutputOnWorkspace.key;
+  }
+  if ("AllocateAddress" in instruction) {
+    return instruction.AllocateAddress.workspace_id;
+  }
+  return null;
+}
+
+/**
+ * The first workspace slot not already claimed by `tx` — one past the highest occupied
+ * slot, or 0 when the transaction claims none. Fee instructions share the workspace with
+ * ordinary instructions, so both lists are scanned.
+ */
+function nextFreeWorkspaceId(tx: UnsignedTransactionV1): number {
+  let next = 0;
+  for (const instruction of [...tx.fee_instructions, ...tx.instructions]) {
+    const slot = workspaceSlotWrittenBy(instruction);
+    if (slot !== null && slot >= next) {
+      next = slot + 1;
+    }
+  }
+  return next;
+}
+
 function workspaceNotDefinedError(name: string): InvalidArgumentError {
   return new InvalidArgumentError(
     `No workspace variable named "${name}" has been defined. ` +
@@ -283,16 +320,34 @@ export class TransactionBuilder {
     return this;
   }
 
+  /**
+   * Adopt an existing transaction and keep building on it.
+   *
+   * The adopted transaction is **copied**, not aliased: subsequent builder calls must not
+   * reach back into the caller's object. The manual co-signing flow ships
+   * `JSON.stringify(unsigned)` across a boundary, so mutating a transaction the caller has
+   * already serialized or signed makes the two sides disagree — surfacing only at submit
+   * time as the opaque engine error `"Transaction has one or more invalid signature(s)"`.
+   * This mirrors the copy {@link buildUnsignedTransaction} makes on the way out.
+   */
   public withUnsignedTransaction(unsignedTransaction: UnsignedTransactionV1): this {
     // `blobs` is required on the binding type but may still be absent on a value that
     // crossed a JSON boundary (the wire struct defaults it), so keep the fallback.
     this.unsignedTransaction = {
       ...unsignedTransaction,
-      blobs: unsignedTransaction.blobs ?? [],
+      instructions: [...unsignedTransaction.instructions],
+      fee_instructions: [...unsignedTransaction.fee_instructions],
+      inputs: [...unsignedTransaction.inputs],
+      blobs: [...(unsignedTransaction.blobs ?? [])],
     };
-    // Reset Workspace State
+    // Workspace *names* are not recoverable from the wire form, so the name → id mapping
+    // starts empty and adopted buckets stay unaddressable by name (as before). The *slots*
+    // those instructions occupy are recoverable, though, and must not be handed out again:
+    // workspace ids are positional, so re-issuing a live slot means the next `saveVar`
+    // clobbers it and the adopted instruction reading it consumes the wrong bucket, with
+    // no diagnostic. Resume allocation past the highest slot already in use.
     this.allocatedIds = new Map();
-    this.currentId = 0;
+    this.currentId = nextFreeWorkspaceId(this.unsignedTransaction);
     return this;
   }
 

--- a/packages/ootle/src/builder.ts
+++ b/packages/ootle/src/builder.ts
@@ -31,19 +31,23 @@ function templateAddressToHash32(address: PublishedTemplateAddress): string {
 }
 
 /**
- * The workspace slot an instruction **writes**, or `null` if it writes none.
+ * The workspace slot an instruction **allocates**, or `null` if it allocates none.
  *
- * Only two instructions claim a slot: `PutLastInstructionOutputOnWorkspace` (what
- * `saveVar` emits) and `AllocateAddress`. Everything else that mentions a workspace id
- * — `CallMethod`'s `{ Workspace }` call target, `{ Workspace: WorkspaceOffsetId }` args,
- * `CreateAccount.bucket_workspace_id` — *reads* an existing slot.
+ * Mirrors `Instruction::allocated_workspace_id` in the Rust `tari_transaction` crate
+ * (`crates/transaction/src/v1/instruction.rs`) — keep the two in step. Exactly three
+ * instructions claim a slot; everything else that mentions a workspace id *reads* one
+ * (`CallMethod`'s `{ Workspace }` call target, `{ Workspace: WorkspaceOffsetId }` args,
+ * `TakeFromBucket.input_bucket`, `CreateAccount.bucket_workspace_id`).
  */
-function workspaceSlotWrittenBy(instruction: Instruction): number | null {
+function allocatedWorkspaceId(instruction: Instruction): number | null {
   if (typeof instruction !== "object" || instruction === null) {
     return null;
   }
   if ("PutLastInstructionOutputOnWorkspace" in instruction) {
     return instruction.PutLastInstructionOutputOnWorkspace.key;
+  }
+  if ("TakeFromBucket" in instruction) {
+    return instruction.TakeFromBucket.output_bucket;
   }
   if ("AllocateAddress" in instruction) {
     return instruction.AllocateAddress.workspace_id;
@@ -52,19 +56,61 @@ function workspaceSlotWrittenBy(instruction: Instruction): number | null {
 }
 
 /**
- * The first workspace slot not already claimed by `tx` — one past the highest occupied
- * slot, or 0 when the transaction claims none. Fee instructions share the workspace with
- * ordinary instructions, so both lists are scanned.
+ * Name → workspace-slot allocation for ONE workspace scope.
+ *
+ * Mirrors the Rust `WorkspaceIds` (`crates/transaction/src/builder/workspace_ids.rs`).
+ * Slots are positional, so the counter must never hand out a slot an instruction in the
+ * same scope already claimed — {@link observeAllocated} is how a slot that arrived on a
+ * pre-built instruction (rather than through {@link insert}) is accounted for.
  */
-function nextFreeWorkspaceId(tx: UnsignedTransactionV1): number {
-  let next = 0;
-  for (const instruction of [...tx.fee_instructions, ...tx.instructions]) {
-    const slot = workspaceSlotWrittenBy(instruction);
-    if (slot !== null && slot >= next) {
-      next = slot + 1;
+class WorkspaceIds {
+  private nextId = 0;
+  private readonly ids = new Map<string, number>();
+
+  /** Claim the next free slot for `name`. */
+  public insert(name: string): number {
+    const id = this.nextId;
+    this.ids.set(name, id);
+    this.nextId += 1;
+    return id;
+  }
+
+  public get(name: string): number | undefined {
+    return this.ids.get(name);
+  }
+
+  /** The next slot {@link insert} would hand out. */
+  public get next(): number {
+    return this.nextId;
+  }
+
+  /**
+   * Account for a slot claimed by an instruction the builder did not allocate itself
+   * (`addInstruction`, `withInstructions`, or an adopted transaction). Rust does this
+   * inline in `add_instruction`.
+   */
+  public observeAllocated(id: number): void {
+    if (id + 1 > this.nextId) {
+      this.nextId = id + 1;
     }
   }
-  return next;
+
+  /** Forget every name and restart allocation at 0. */
+  public reset(): void {
+    this.nextId = 0;
+    this.ids.clear();
+  }
+
+  /** Reset, then account for every slot the given instructions already claim. */
+  public resetFrom(instructions: Instruction[]): void {
+    this.reset();
+    for (const instruction of instructions) {
+      const id = allocatedWorkspaceId(instruction);
+      if (id !== null) {
+        this.observeAllocated(id);
+      }
+    }
+  }
 }
 
 function workspaceNotDefinedError(name: string): InvalidArgumentError {
@@ -116,8 +162,12 @@ export type UnsignedTransactionWithBlobs = UnsignedTransactionV1;
  */
 export class TransactionBuilder {
   private unsignedTransaction: UnsignedTransactionV1;
-  private allocatedIds: Map<string, number>;
-  private currentId: number;
+  // Two INDEPENDENT workspace scopes, matching the Rust builder's separate fee builder.
+  // The engine drops the whole workspace between the fee instructions and the main ones
+  // (`WorkspaceAction::DropAll` in the engine's transaction processor), so a slot used by
+  // a fee instruction says nothing about which slots the main instructions may use.
+  private workspaceIds: WorkspaceIds;
+  private feeWorkspaceIds: WorkspaceIds;
 
   constructor(network: Network | number) {
     this.unsignedTransaction = {
@@ -131,8 +181,8 @@ export class TransactionBuilder {
       is_seal_signer_authorized: false,
       blobs: [],
     };
-    this.allocatedIds = new Map();
-    this.currentId = 0;
+    this.workspaceIds = new WorkspaceIds();
+    this.feeWorkspaceIds = new WorkspaceIds();
   }
 
   public static new(network: Network | number): TransactionBuilder {
@@ -275,28 +325,55 @@ export class TransactionBuilder {
   }
 
   public addInstruction(instruction: Instruction): this {
+    this.observeAllocations(this.workspaceIds, [instruction]);
     this.unsignedTransaction.instructions.push(instruction);
     return this;
   }
 
   public addFeeInstruction(instruction: Instruction): this {
+    this.observeAllocations(this.feeWorkspaceIds, [instruction]);
     this.unsignedTransaction.fee_instructions.push(instruction);
     return this;
   }
 
   public withInstructions(instructions: Instruction[]): this {
+    this.observeAllocations(this.workspaceIds, instructions);
     this.unsignedTransaction.instructions.push(...instructions);
     return this;
   }
 
   public withFeeInstructions(instructions: Instruction[]): this {
+    this.observeAllocations(this.feeWorkspaceIds, instructions);
     this.unsignedTransaction.fee_instructions.push(...instructions);
     return this;
   }
 
+  /**
+   * Account for slots claimed by instructions the builder did not allocate itself, so a
+   * later `saveVar` cannot re-issue one. Rust does this inline in `add_instruction`.
+   */
+  private observeAllocations(scope: WorkspaceIds, instructions: Instruction[]): void {
+    for (const instruction of instructions) {
+      const id = allocatedWorkspaceId(instruction);
+      if (id !== null) {
+        scope.observeAllocated(id);
+      }
+    }
+  }
+
+  /**
+   * Build the fee instructions with a nested builder, mirroring the Rust builder's separate
+   * fee-instruction builder. The nested builder gets its own workspace scope — correct,
+   * because the engine clears the workspace between the fee and main instruction runs.
+   *
+   * Note this REPLACES any fee instructions already set, as it always has.
+   */
   public withFeeInstructionsBuilder(builder: (b: TransactionBuilder) => TransactionBuilder): this {
     const inner = builder(new TransactionBuilder(this.unsignedTransaction.network));
     this.unsignedTransaction.fee_instructions = inner.unsignedTransaction.instructions;
+    // Adopt the nested builder's slot accounting so later `addFeeInstruction` calls on the
+    // outer builder cannot re-issue a slot the nested one already claimed.
+    this.feeWorkspaceIds.resetFrom(this.unsignedTransaction.fee_instructions);
     return this;
   }
 
@@ -346,8 +423,8 @@ export class TransactionBuilder {
     // workspace ids are positional, so re-issuing a live slot means the next `saveVar`
     // clobbers it and the adopted instruction reading it consumes the wrong bucket, with
     // no diagnostic. Resume allocation past the highest slot already in use.
-    this.allocatedIds = new Map();
-    this.currentId = nextFreeWorkspaceId(this.unsignedTransaction);
+    this.workspaceIds.resetFrom(this.unsignedTransaction.instructions);
+    this.feeWorkspaceIds.resetFrom(this.unsignedTransaction.fee_instructions);
     return this;
   }
 
@@ -378,14 +455,11 @@ export class TransactionBuilder {
   // Internal helpers
 
   private addNamedId(name: string): number {
-    const id = this.currentId;
-    this.allocatedIds.set(name, id);
-    this.currentId += 1;
-    return id;
+    return this.workspaceIds.insert(name);
   }
 
   private requireNamedId(name: string): number {
-    const id = this.allocatedIds.get(name);
+    const id = this.workspaceIds.get(name);
     if (id === undefined) throw workspaceNotDefinedError(name);
     return id;
   }


### PR DESCRIPTION
## Summary

The two pre-existing `TransactionBuilder.withUnsignedTransaction` bugs surfaced in review of #120, split out as promised rather than absorbed into a dependency bump. Both were confirmed by reproduction before any fix was written; the tests in this PR fail on `main` and pass here.

Both defects are in the "adopt an existing transaction and keep building" path, and in both cases `buildUnsignedTransaction` already does the right thing a few lines away.

## 1. Adopting aliased the caller's arrays

`withUnsignedTransaction` shallow-spread its argument, so `instructions`, `fee_instructions`, `inputs` and `blobs` stayed pointing at the caller's arrays. Any subsequent builder call mutated the caller's object in place:

```ts
const tx = /* ... */;
TransactionBuilder.new(net).withUnsignedTransaction(tx).publishTemplate(wasmB64);
// tx.instructions and tx.blobs have both grown — tx is not the transaction the caller built.
```

This matters because the documented manual co-signing flow ships `JSON.stringify(unsigned)` across a process boundary. If the local builder keeps building after the snapshot is taken, the two sides hash different transactions and the failure surfaces late, at submit time, as the opaque engine error `"Transaction has one or more invalid signature(s)"` — with nothing pointing at the builder.

Fixed by copying the four arrays on the way in, mirroring the copy `buildUnsignedTransaction` makes on the way out.

## 2. Workspace ids restarted at 0 over occupied slots

Adopting reset `currentId` to 0 regardless of what the adopted instructions already claimed. Workspace ids are **positional slots**, not names, so the next `saveVar` was handed a live one:

```ts
const adopted = new FaucetInvokeBuilder(net, faucet).takeMaxFaucetFunds(account).build();
// adopted already contains PutLastInstructionOutputOnWorkspace { key: 0 }

TransactionBuilder.new(net).withUnsignedTransaction(adopted)
  .callMethod(...).saveVar("bucket");
// saveVar is handed key 0 again -> slot 0 written twice
```

The second write clobbers the slot, and the adopted instruction that reads it consumes the wrong bucket. No builder-side diagnostic, no engine error — just the wrong funds moving.

Allocation now resumes past the highest slot already claimed. Fee instructions are scanned too, since they share the workspace with ordinary instructions. Only `PutLastInstructionOutputOnWorkspace` and `AllocateAddress` claim a slot — `CallMethod`'s `{ Workspace }` target, `{ Workspace: WorkspaceOffsetId }` args and `CreateAccount.bucket_workspace_id` all *read* one, and are correctly left alone.

Workspace **names** are still cleared on adopt: they are not recoverable from the wire form, only the slots are. That behaviour is unchanged and pinned by a test.

## Also

Drops the now-stale `ignoreDependencies: ["prettier"]` from `knip.ts`. The `format` scripts added with the CI format check in #120 reference prettier directly, so knip resolves it on its own and was reporting the entry as unnecessary.

## Test plan

New `packages/ootle/src/builder.adopt.test.ts` — 10 cases. The 8 covering the two defects fail on `main` and pass here; the other 2 pin behaviour that was already correct (allocation still starts at 0 when nothing is occupied; adopted names stay unresolvable).

Verified on a clean checkout of `ff2da20` (no untracked local dirs), Linux:

- `pnpm -r build` — clean
- `pnpm -r test` — 45 files / 429 tests passing
- `pnpm lint`, `pnpm run format:check`, `pnpm knip` — all clean
- `./scripts/check_versions.sh` — all packages at 0.2.0

No version bump here: 0.2.0 is staged on `main` and unpublished, so this rides along with it. Publishing is tag-gated as of #120.

## Aligned with the Rust builder (`505430e`)

Checked against `dan/crates/transaction/src/builder` and corrected three things my first pass got wrong:

**`TakeFromBucket.output_bucket` allocates a slot too.** Rust's `Instruction::allocated_workspace_id` lists three allocators; I had two. A `TakeFromBucket` output slot could still be handed out twice.

**Fee instructions are a separate workspace scope.** I had seeded one shared counter from both instruction lists. That is not how the engine numbers them — the transaction processor issues `WorkspaceAction::DropAll` between the fee run and the main run ("Clear the workspace before executing the main instructions"), and Rust models it as a distinct fee-instruction builder with its own `WorkspaceIds`. Fee and main slots are now independent.

**The counter must advance for any pre-built instruction, not just on adopt.** Rust does this inline in `add_instruction`. `addInstruction`, `withInstructions` and their fee counterparts are public escape hatches carrying the identical collision, so they account for allocated slots now as well.

The name→slot map and counter are extracted into a `WorkspaceIds` class mirroring the Rust type, instantiated once per scope. `allocatedWorkspaceId` mirrors `Instruction::allocated_workspace_id` and is commented as needing to stay in step with it.

### One deliberate divergence

Rust's `with_unsigned_transaction` resets both scopes to 0 and does **not** seed from the adopted instructions — adopted instructions bypass `add_instruction`, so the bump-on-add rule never runs for them. That is the same latent collision this PR fixes on the TS side, so I kept the seeding rather than reproducing the gap. `with_instructions` in Rust documents the intended rule explicitly ("Instructions which allocate workspace IDs will update the internal workspace ID counter accordingly"); `with_unsigned_transaction` just misses it. **Probably worth a matching upstream fix.**

Each of the four new behaviours was mutation-tested — reverting any one of them (drop the `TakeFromBucket` allocator, collapse the fee scope into the main one, remove the bump from `addInstruction`/`withInstructions`) fails the suite.

Test count is now 14 in `builder.adopt.test.ts`; workspace suite totals 333 in `@tari-project/ootle`, 433 across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHj1uU5ZxFD13XHa3wrNCD
