### PR TITLE
fix(ci): make the npm publish actually authenticate

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -9,6 +9,26 @@
 # The tag must match the workspace version in the root package.json, and every
 # packages/* manifest must inherit it (check_versions.sh). npm publishes are
 # immutable, so both are verified before anything is pushed to the registry.
+#
+# ## Authentication: npm trusted publishing (OIDC), no stored token
+#
+# There is deliberately no NPM_TOKEN. Each package must have a trusted publisher
+# configured on npmjs.com pointing at this repository and THIS workflow filename:
+#
+#   Repository:  tari-project/ootle.ts
+#   Workflow:    npm_publish.yml
+#
+# Two constraints follow from that, and both are why this job does not simply run
+# `pnpm publish -r`:
+#
+#  1. Only the npm CLI implements the OIDC exchange — pnpm does not (verified: pnpm
+#     10.32 contains no reference to ACTIONS_ID_TOKEN_REQUEST_URL). A `pnpm publish`
+#     here authenticates with nothing and npm answers `404 Not Found - PUT`, because
+#     the registry masks "you may not write this package" as "not found".
+#  2. npm cannot read the manifests directly: they use pnpm's `catalog:` and
+#     `workspace:` protocols, which only pnpm resolves. So each package is packed
+#     with `pnpm pack` — which rewrites those to real semver ranges — and the
+#     resulting tarball is handed to `npm publish`.
 name: Publish Package to npmjs
 
 on:
@@ -31,7 +51,10 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
+
+      # Node 22 ships npm 10.x; trusted publishing needs >= 11.5.1.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Verify the tag matches the workspace version
         run: |
@@ -53,6 +76,32 @@ jobs:
       # publish a package at the wrong version, which npm will not let us take back.
       - run: ./scripts/check_versions.sh
 
+      # Fail in seconds rather than after a full build. This is the check that would
+      # have caught the credential gap in June: between switching to trusted publishing
+      # and the first real release, every run hit the "already published, skipping"
+      # branch, so the missing auth path was never exercised and the job stayed green.
+      - name: Verify publish prerequisites
+        run: |
+          set -euo pipefail
+
+          NPM_VERSION=$(npm --version)
+          echo "npm version: $NPM_VERSION"
+          MIN="11.5.1"
+          if [ "$(printf '%s\n%s\n' "$MIN" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN" ]; then
+            echo "::error::npm $NPM_VERSION is too old for trusted publishing (need >= $MIN)."
+            exit 1
+          fi
+
+          # Present only when the job is granted `id-token: write`. Without it there is
+          # no credential of any kind and every publish would 404.
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::No OIDC token endpoint in the environment."
+            echo "The job needs 'permissions: id-token: write' for npm trusted publishing."
+            exit 1
+          fi
+          echo "OIDC token endpoint present."
+
+      - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
 
       - name: Publish all modules to NPM
@@ -67,7 +116,7 @@ jobs:
           echo "Sentinel package: $SENTINEL"
           echo "Local version:    $LOCAL_VERSION"
 
-          REMOTE_VERSION=$(pnpm info "$SENTINEL" version 2>/dev/null || echo "NOT_FOUND")
+          REMOTE_VERSION=$(npm view "$SENTINEL" version 2>/dev/null || echo "NOT_FOUND")
           echo "Remote version:   $REMOTE_VERSION"
 
           if [ "$REMOTE_VERSION" = "$LOCAL_VERSION" ]; then
@@ -76,4 +125,27 @@ jobs:
           fi
 
           echo "== Publishing =="
-          pnpm publish --provenance -r --no-git-checks
+          mkdir -p "$RUNNER_TEMP/tarballs"
+
+          # Order is irrelevant: npm does not resolve a package's dependencies at
+          # publish time, so an inter-package range may point at a version that is
+          # seconds away from existing.
+          for manifest in packages/*/package.json; do
+            pkg_dir="$(dirname "$manifest")"
+            name=$(node -p "require('./$manifest').name")
+
+            if [ "$(node -p "require('./$manifest').private === true")" = "true" ]; then
+              echo "-- $name is private, skipping"
+              continue
+            fi
+
+            echo "-- packing $name"
+            # `pnpm pack` resolves `catalog:` / `workspace:` into real ranges; the raw
+            # manifest would publish those protocol strings verbatim and break installs.
+            # `--json` so the path is parsed rather than scraped off the last log line.
+            tarball=$(cd "$pkg_dir" && pnpm pack --json --pack-destination "$RUNNER_TEMP/tarballs" \
+              | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>process.stdout.write(JSON.parse(d).filename))")
+
+            echo "-- publishing $name from $tarball"
+            npm publish "$tarball" --provenance --access public
+          done

--- a/packages/ootle-indexer/package.json
+++ b/packages/ootle-indexer/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tari-project/ootle-indexer",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/ootle.ts.git",
+    "directory": "packages/ootle-indexer"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ootle-secret-key-wallet/package.json
+++ b/packages/ootle-secret-key-wallet/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tari-project/ootle-secret-key-wallet",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/ootle.ts.git",
+    "directory": "packages/ootle-secret-key-wallet"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ootle-wallet-daemon-signer/package.json
+++ b/packages/ootle-wallet-daemon-signer/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tari-project/ootle-wallet-daemon-signer",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/ootle.ts.git",
+    "directory": "packages/ootle-wallet-daemon-signer"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/ootle/package.json
+++ b/packages/ootle/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tari-project/ootle",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tari-project/ootle.ts.git",
+    "directory": "packages/ootle"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Why the v0.2.0 publish 404'd

`npm error 404 Not Found - PUT https://registry.npmjs.org/@tari-project%2footle` reads like the package doesn't exist, but npm deliberately masks *"you may not write this package"* as 404 for scoped packages. **The job had no credentials at all.**

This is older than the tag gating I added in #120 — that change only made it visible.

| evidence | finding |
|---|---|
| `npm view @tari-project/ootle versions` | only `0.1.0`, published 2026-06-01 **09:30** |
| workflow run history | 4 runs since, all "successful" — every one exited via `already published, skipping`, including the 2026-06-01 **18:24** run |
| `gh secret list` | empty — no `NPM_TOKEN` anywhere |
| failed run log | zero OIDC activity; straight to an unauthenticated `PUT` |

Commit `eea34b0` switched to trusted publishing and removed `NPM_TOKEN`. But **pnpm does not implement npm's OIDC exchange** — pnpm 10.32's bundle contains no `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, or `npm/v1/oidc`. (The `trustedPublisher` strings that do appear are in `trustChecks.js`, an *install-time* trust-policy feature.) So `pnpm publish` has authenticated with nothing since June, and the skip branch kept the job green the whole time.

**This workflow has never actually published anything.** 0.1.0 predates it.

## The fix — keeping trusted publishing, no stored token

- **Publish with the npm CLI**, upgraded to ≥ 11.5.1 (node 22 ships npm 10.x). It is the only client that performs the OIDC exchange.
- **Pack with `pnpm pack` first, publish the tarball.** npm cannot read these manifests directly: they use pnpm's `catalog:` and `workspace:` protocols. Publishing them raw would ship `"@tari-project/ootle": "workspace:"` verbatim and break every install. `pnpm pack` resolves them — verified on the real tarballs:
  ```
  "@tari-project/ootle-ts-bindings": "^1.47.1"
  "@tari-project/ootle-wasm":        "^0.38.0"
  "@tari-project/ootle":             "0.2.0"
  ```
- **Add `repository` to the four manifests.** `npm publish --provenance` hard-requires it. None of them had it, so the run would have failed again immediately after the auth fix — this was the next landmine.
- **Add a prerequisites check before the build** (npm version, OIDC endpoint present). This is the check that would have caught the June breakage in seconds instead of two months.

The tarball path is read from `pnpm pack --json` rather than scraped off the last log line.

## Required before the next tag — action needed on npmjs.com

Trusted publishing is configured **per package**. All four need a trusted publisher pointing at:

- **Repository:** `tari-project/ootle.ts`
- **Workflow:** `npm_publish.yml`

for `@tari-project/ootle`, `@tari-project/ootle-indexer`, `@tari-project/ootle-secret-key-wallet`, `@tari-project/ootle-wallet-daemon-signer`.

Without that the publish will 404 again — the workflow cannot create the trust relationship, only use it.

## Test plan

The OIDC exchange itself cannot be exercised locally; the first tag push after the npmjs-side config is what proves it. Everything up to the registry call was verified on this branch:

- The full pack-and-publish loop runs over all four packages, producing correct tarballs with `catalog:`/`workspace:` resolved and `repository` present
- Each tarball passes `npm publish --dry-run --access public`
- `pnpm -r build`, `pnpm -r test` (45 files), `pnpm lint`, `pnpm run format:check`, `pnpm knip`, `check_versions.sh` — all clean

Re-tagging after merge is safe: the already-published guard makes a repeat tag a no-op, and 0.2.0 is not on the registry yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHj1uU5ZxFD13XHa3wrNCD
