### PR TITLE
feat(deps)!: upgrade the tari package set to the 0.39 protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ console.log(substate);
 ### 2. Build and submit a transaction (wallet daemon)
 
 ```ts
-import { TransactionBuilder, sendTransaction, Network } from "@tari-project/ootle";
+import { TransactionBuilder, sendTransaction, Network, resolveMaxEpoch } from "@tari-project/ootle";
 import { ProviderBuilder } from "@tari-project/ootle-indexer";
 import { WalletDaemonSigner } from "@tari-project/ootle-wallet-daemon-signer";
 
 const provider = await ProviderBuilder.new().withNetwork(Network.LocalNet).connect();
 const signer = await WalletDaemonSigner.connect({ url: "http://localhost:18103", authToken: "…" });
 
-const unsignedTx = TransactionBuilder.new(Network.LocalNet)
+const unsignedTx = TransactionBuilder.new(Network.LocalNet, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(await signer.getAddress(), 1000n)
   .callMethod({ componentAddress: accountAddress, methodName: "withdraw" }, [
     { Literal: resourceAddress },
@@ -113,6 +113,7 @@ import {
   TARI_RESOURCE_ADDRESS,
   XTR_FAUCET_COMPONENT_ADDRESS,
   defaultIndexerUrl,
+  resolveMaxEpoch,
   sendTransaction,
 } from "@tari-project/ootle";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
@@ -121,16 +122,19 @@ import { EphemeralKeySigner, SecretKeyWallet } from "@tari-project/ootle-secret-
 const url = process.env.OOTLE_INDEXER_URL ?? defaultIndexerUrl(Network.LocalNet);
 const provider = await IndexerProvider.connect({ url, network: Network.LocalNet });
 
+// Every transaction needs a `max_epoch`; this reads the chain tip and adds the default window.
+const maxEpoch = await resolveMaxEpoch(provider);
+
 const sender = SecretKeyWallet.randomWithViewKey(Network.LocalNet);
 const recipient = EphemeralKeySigner.generate(Network.LocalNet);
 
-const faucetTx = new FaucetInvokeBuilder(Network.LocalNet, XTR_FAUCET_COMPONENT_ADDRESS)
+const faucetTx = new FaucetInvokeBuilder(Network.LocalNet, maxEpoch, XTR_FAUCET_COMPONENT_ADDRESS)
   .feeTransactionPayFromComponent(await sender.getAddress(), 1000n)
   .takeFaucetFunds(await sender.getAddress(), 10_000_000n)
   .build();
 await sendTransaction(provider, sender, faucetTx);
 
-const transferTx = new AccountInvokeBuilder(Network.LocalNet, await sender.getAddress())
+const transferTx = new AccountInvokeBuilder(Network.LocalNet, maxEpoch)
   .feeTransactionPayFromComponent(await sender.getAddress(), 1000n)
   .publicTransfer(await sender.getAddress(), TARI_RESOURCE_ADDRESS, 2_000_000n, await recipient.getAddress())
   .build();
@@ -159,6 +163,7 @@ ootle.ts uses two core abstractions:
 Implemented by `IndexerProvider`. Provides:
 
 - `getSubstate(id)` / `fetchSubstates(ids)`
+- `getCurrentEpoch()` — the chain tip, for a transaction's mandatory `max_epoch`
 - `resolveInputs(inputs)` — fills in missing versions before signing
 - `submitTransaction(envelope)`
 - `getTransactionResult(txId)`
@@ -234,7 +239,7 @@ enum Network {
 Fluent builder for `UnsignedTransactionV1`.
 
 ```ts
-const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
+const unsignedTx = TransactionBuilder.new(Network.Esmeralda, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callFunction({ templateAddress, functionName: "new" }, [literalArg("hello")])
   .saveVar("component")
@@ -306,16 +311,18 @@ const signatures = await wallet.signTransaction(unsignedTx);
 Pre-built builders for the standard account and faucet templates.
 
 ```ts
-import { AccountInvokeBuilder, FaucetInvokeBuilder } from "@tari-project/ootle";
+import { AccountInvokeBuilder, FaucetInvokeBuilder, resolveMaxEpoch } from "@tari-project/ootle";
+
+const maxEpoch = await resolveMaxEpoch(provider);
 
 // Withdraw from account
-const tx = new AccountInvokeBuilder(Network.Esmeralda, accountAddress)
+const tx = new AccountInvokeBuilder(Network.Esmeralda, maxEpoch)
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .publicTransfer(accountAddress, resourceAddress, 500n, recipientAddress)
   .build();
 
 // Take faucet funds
-const tx = new FaucetInvokeBuilder(Network.Esmeralda, faucetAddress)
+const tx = new FaucetInvokeBuilder(Network.Esmeralda, maxEpoch, faucetAddress)
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .takeFaucetFunds(accountAddress, 10_000n)
   .build();

--- a/docs/src/content/docs/advanced/builtin-templates.md
+++ b/docs/src/content/docs/advanced/builtin-templates.md
@@ -5,14 +5,16 @@ description: Pre-built builders for standard account and faucet operations.
 
 The SDK includes typed builder classes for the two standard builtin templates: **Account** and **Faucet**. These wrap common patterns so you don't have to construct raw `callMethod` instructions manually.
 
+Both take the transaction's mandatory `maxEpoch` as their second argument — see [Epoch Bounds](/transactions/epoch-bounds/).
+
 ## AccountInvokeBuilder
 
 Build transactions that operate on account components.
 
 ```ts
-import { AccountInvokeBuilder, Network } from "@tari-project/ootle";
+import { AccountInvokeBuilder, Network, resolveMaxEpoch } from "@tari-project/ootle";
 
-const tx = new AccountInvokeBuilder(Network.Esmeralda, accountAddress)
+const tx = new AccountInvokeBuilder(Network.Esmeralda, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .publicTransfer(accountAddress, resourceAddress, 500n, recipientAddress)
   .build();
@@ -23,9 +25,9 @@ const tx = new AccountInvokeBuilder(Network.Esmeralda, accountAddress)
 Build transactions that interact with faucet components (for testnet token distribution).
 
 ```ts
-import { FaucetInvokeBuilder, Network } from "@tari-project/ootle";
+import { FaucetInvokeBuilder, Network, resolveMaxEpoch } from "@tari-project/ootle";
 
-const tx = new FaucetInvokeBuilder(Network.Esmeralda, faucetAddress)
+const tx = new FaucetInvokeBuilder(Network.Esmeralda, await resolveMaxEpoch(provider), faucetAddress)
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .takeFaucetFunds(accountAddress, 10_000n)
   .build();

--- a/docs/src/content/docs/getting-started/provider-and-signer.md
+++ b/docs/src/content/docs/getting-started/provider-and-signer.md
@@ -11,6 +11,7 @@ A `Provider` gives read-only access to the Ootle network:
 
 ```ts
 interface Provider {
+  getCurrentEpoch(): Promise<number>;
   getSubstate(id: string): Promise<IndexerGetSubstateResponse>;
   fetchSubstates(ids: string[]): Promise<GetSubstatesResponse>;
   listRecentTransactions(params: ListRecentTransactionsRequest): Promise<ListRecentTransactionsResponse>;

--- a/docs/src/content/docs/getting-started/quick-start-browser.md
+++ b/docs/src/content/docs/getting-started/quick-start-browser.md
@@ -24,7 +24,7 @@ console.log(substate);
 ## 2. Submit a transaction (wallet daemon)
 
 ```ts
-import { TransactionBuilder, sendTransaction, Network } from "@tari-project/ootle";
+import { TransactionBuilder, sendTransaction, Network, resolveMaxEpoch } from "@tari-project/ootle";
 import { ProviderBuilder } from "@tari-project/ootle-indexer";
 import { WalletDaemonSigner } from "@tari-project/ootle-wallet-daemon-signer";
 
@@ -37,7 +37,7 @@ const signer = await WalletDaemonSigner.connect({
 
 const accountAddress = await signer.getAddress();
 
-const unsignedTx = TransactionBuilder.new(Network.LocalNet)
+const unsignedTx = TransactionBuilder.new(Network.LocalNet, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callMethod({ componentAddress: accountAddress, methodName: "withdraw" }, [
     { Literal: resourceAddress },

--- a/docs/src/content/docs/getting-started/quick-start-node.md
+++ b/docs/src/content/docs/getting-started/quick-start-node.md
@@ -66,6 +66,7 @@ import {
   TARI_RESOURCE_ADDRESS,
   XTR_FAUCET_COMPONENT_ADDRESS,
   defaultIndexerUrl,
+  resolveMaxEpoch,
   sendTransaction,
 } from "@tari-project/ootle";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
@@ -79,11 +80,13 @@ const sender = SecretKeyWallet.randomWithViewKey(Network.LocalNet);
 const recipient = EphemeralKeySigner.generate(Network.LocalNet);
 const senderAddress = await sender.getAddress();
 const recipientAddress = await recipient.getAddress();
+// Every transaction needs a `max_epoch`; this reads the chain tip and adds the default window.
+const maxEpoch = await resolveMaxEpoch(provider);
 console.log(`Sender:    ${senderAddress}`);
 console.log(`Recipient: ${recipientAddress}`);
 
 // 2. Faucet 10 TARI into the sender's freshly-created account.
-const faucetTx = new FaucetInvokeBuilder(Network.LocalNet, XTR_FAUCET_COMPONENT_ADDRESS)
+const faucetTx = new FaucetInvokeBuilder(Network.LocalNet, maxEpoch, XTR_FAUCET_COMPONENT_ADDRESS)
   .feeTransactionPayFromComponent(senderAddress, 1000n)
   .takeFaucetFunds(senderAddress, 10_000_000n) // 10 TARI in µTari
   .build();
@@ -93,7 +96,7 @@ console.log(`Faucet committed: ${faucetReceipt.transaction_id}`);
 // 3. Public-transfer 2 TARI to the recipient. `publicTransfer` emits a
 //    `withdraw` from the sender + `deposit` to the recipient; the engine
 //    creates the recipient's account inline if it doesn't exist yet.
-const transferTx = new AccountInvokeBuilder(Network.LocalNet, senderAddress)
+const transferTx = new AccountInvokeBuilder(Network.LocalNet, maxEpoch)
   .feeTransactionPayFromComponent(senderAddress, 1000n)
   .publicTransfer(senderAddress, TARI_RESOURCE_ADDRESS, 2_000_000n, recipientAddress)
   .build();

--- a/docs/src/content/docs/providers/indexer-provider.md
+++ b/docs/src/content/docs/providers/indexer-provider.md
@@ -46,6 +46,9 @@ const list = await provider.listRecentTransactions({ limit: 5, last_id: null });
 
 // Template definition (ABI)
 const template = await provider.getTemplateDefinition(templateAddress);
+
+// The epoch the network is on — a transaction's `max_epoch` is derived from this
+const epoch = await provider.getCurrentEpoch();
 ```
 
 ## Submit and watch transactions

--- a/docs/src/content/docs/signers/wallet-daemon.md
+++ b/docs/src/content/docs/signers/wallet-daemon.md
@@ -40,7 +40,7 @@ const signatures = await signer.signTransaction(unsignedTx);
 ## Full example
 
 ```ts
-import { TransactionBuilder, sendTransaction, Network } from "@tari-project/ootle";
+import { TransactionBuilder, sendTransaction, Network, resolveMaxEpoch } from "@tari-project/ootle";
 import { ProviderBuilder } from "@tari-project/ootle-indexer";
 import { WalletDaemonSigner } from "@tari-project/ootle-wallet-daemon-signer";
 
@@ -53,7 +53,7 @@ const signer = await WalletDaemonSigner.connect({
 
 const accountAddress = await signer.getAddress();
 
-const unsignedTx = TransactionBuilder.new(Network.LocalNet)
+const unsignedTx = TransactionBuilder.new(Network.LocalNet, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callMethod({ componentAddress: accountAddress, methodName: "withdraw" }, [
     { Literal: resourceAddress },

--- a/docs/src/content/docs/transactions/call-function.md
+++ b/docs/src/content/docs/transactions/call-function.md
@@ -8,9 +8,9 @@ description: Call a static function on a published template.
 ## Usage
 
 ```ts
-import { TransactionBuilder, literalArg, Network } from "@tari-project/ootle";
+import { TransactionBuilder, literalArg, Network, resolveMaxEpoch } from "@tari-project/ootle";
 
-const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
+const unsignedTx = TransactionBuilder.new(Network.Esmeralda, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callFunction(
     {

--- a/docs/src/content/docs/transactions/epoch-bounds.md
+++ b/docs/src/content/docs/transactions/epoch-bounds.md
@@ -3,11 +3,29 @@ title: Epoch Bounds
 description: Limit the time window during which a transaction is valid.
 ---
 
-Epoch bounds constrain when a transaction can be executed. This is useful for time-sensitive operations where a stale transaction should not be processed.
+Every transaction carries a **mandatory** `max_epoch`: the last epoch in which it may be sequenced. A transaction's death is therefore deterministic — an attempt that aborts cannot be retried indefinitely, and a stuck transaction stops being a resubmittable intent once its window closes.
+
+## maxEpoch is a constructor argument
+
+`TransactionBuilder.new(network, maxEpoch)` takes it up front:
+
+```ts
+import { TransactionBuilder, resolveMaxEpoch } from "@tari-project/ootle";
+
+const builder = TransactionBuilder.new(provider.network(), await resolveMaxEpoch(provider));
+```
+
+`resolveMaxEpoch(provider, leadEpochs?)` reads the chain tip via `provider.getCurrentEpoch()` and returns `currentEpoch + leadEpochs`, defaulting to `DEFAULT_TRANSACTION_VALIDITY_EPOCHS` (10). Pass an explicit number when you want a different window:
+
+```ts
+const maxEpoch = await resolveMaxEpoch(provider, 50);
+```
+
+The network caps the window at `MAX_TRANSACTION_VALIDITY_EPOCHS` (2160 epochs, roughly 30 days) past the current epoch. A transaction reaching further ahead is aborted with `ValidityWindowTooLong`.
 
 ## withMinEpoch
 
-The transaction is only valid starting from this epoch:
+The transaction is only valid starting from this epoch. Unlike `max_epoch`, it is optional and defaults to unset:
 
 ```ts
 builder.withMinEpoch(100);
@@ -15,7 +33,7 @@ builder.withMinEpoch(100);
 
 ## withMaxEpoch
 
-The transaction is only valid until this epoch:
+Overrides the window set at construction:
 
 ```ts
 builder.withMaxEpoch(200);
@@ -24,7 +42,7 @@ builder.withMaxEpoch(200);
 ## Combining both
 
 ```ts
-const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
+const unsignedTx = TransactionBuilder.new(Network.Esmeralda, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callMethod({ componentAddress: accountAddress, methodName: "withdraw" }, [
     { Literal: resourceAddress },
@@ -38,3 +56,13 @@ const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
 ```
 
 If the network's current epoch is outside the specified range, the transaction will be rejected.
+
+## Nonce
+
+The transaction id excludes the seal signature's witness data, so two identical bodies sealed by the same key are the _same_ transaction — submitting both executes once. When each submission must execute independently, stamp a distinct nonce per intent:
+
+```ts
+builder.withNonce(1);
+```
+
+It defaults to `0`.

--- a/docs/src/content/docs/transactions/transaction-builder.md
+++ b/docs/src/content/docs/transactions/transaction-builder.md
@@ -8,17 +8,21 @@ description: Compose transaction instructions with a fluent API.
 ## Create a builder
 
 ```ts
-import { TransactionBuilder, Network } from "@tari-project/ootle";
+import { TransactionBuilder, Network, resolveMaxEpoch } from "@tari-project/ootle";
 
-const builder = TransactionBuilder.new(Network.Esmeralda);
+const builder = TransactionBuilder.new(Network.Esmeralda, await resolveMaxEpoch(provider));
 ```
+
+Both arguments are required. The second is the transaction's `max_epoch` — the last epoch in
+which it may be sequenced — which every transaction must carry. See
+[Epoch Bounds](/transactions/epoch-bounds/).
 
 ## Build a transaction
 
 A typical transaction: withdraw tokens from one account and deposit them into another.
 
 ```ts
-const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
+const unsignedTx = TransactionBuilder.new(Network.Esmeralda, await resolveMaxEpoch(provider))
   .feeTransactionPayFromComponent(accountAddress, 1000n)
   .callMethod({ componentAddress: accountAddress, methodName: "withdraw" }, [
     { Literal: resourceAddress },
@@ -44,6 +48,7 @@ const unsignedTx = TransactionBuilder.new(Network.Esmeralda)
 | `allocateAddress(type, name)`                             | Pre-allocate an address              |
 | `addInput(req)` / `withInputs(reqs)`                      | Add substate inputs                  |
 | `withMinEpoch(n)` / `withMaxEpoch(n)`                     | Set epoch bounds                     |
+| `withNonce(n)`                                            | Distinguish identical transactions   |
 | `withInstructions(instructions)`                          | Append raw instructions              |
 | `withFeeInstructions(instructions)`                       | Append raw fee instructions          |
 | `dropAllProofsInWorkspace()`                              | Drop all proofs                      |

--- a/examples/_common/src/literal.ts
+++ b/examples/_common/src/literal.ts
@@ -50,18 +50,30 @@ function bytesToHex(bytes: number[]): string {
 }
 
 /**
- * CBOR-encode an `Amount` (u128) as the `[lo_u64, hi_u64]` pair the runtime
- * deserializes via `tari_bor`. Returns the hex form for `InstructionArg::Literal`.
+ * CBOR-encode an `Amount` (u128) the way the runtime's `minicbor` codec does: a plain
+ * CBOR unsigned integer up to `u64::MAX`, and an RFC 8949 tag-2 unsigned bignum
+ * (minimal-length big-endian bytes) above it. Returns the hex form for
+ * `InstructionArg::Literal`.
  */
 export function amountLiteralHex(value: Amount | bigint | number): string {
   const n = typeof value === "bigint" ? value : BigInt(value);
   if (n < 0n) throw new Error(`amount must be non-negative, got ${n}`);
   if (n >> 128n !== 0n) throw new Error(`amount overflows u128: ${n}`);
-  const lo = n & U64_MASK;
-  const hi = (n >> 64n) & U64_MASK;
-  const out: number[] = [0x82];
-  appendCborUint(out, lo);
-  appendCborUint(out, hi);
+  const out: number[] = [];
+  if (n <= U64_MASK) {
+    appendCborUint(out, n);
+    return bytesToHex(out);
+  }
+  const be: number[] = [];
+  let rest = n;
+  while (rest > 0n) {
+    be.unshift(Number(rest & 0xffn));
+    rest >>= 8n;
+  }
+  // Tag(2), then a byte string of `be.length` bytes. The length is 9..16 here, i.e.
+  // below 24, so it rides in the head byte itself (0x40 | len) — 2^64 encodes as
+  // `c249 01 00×8`, matching the runtime.
+  out.push(0xc2, 0x40 | be.length, ...be);
   return bytesToHex(out);
 }
 

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -82,7 +82,7 @@ directly and never think about TS loaders or `--experimental-*` flags.
 
 ## WASM-in-Node runtime story
 
-`@tari-project/ootle-wasm@0.38.0` ships wasm-bindgen glue that self-initializes
+`@tari-project/ootle-wasm@0.39.0` ships wasm-bindgen glue that self-initializes
 on first import. `tsx` runs the file as a plain Node ESM module — there is **no
 Vite transform**, unlike the Vitest test runtime (which inlines WASM through
 `vite-plugin-wasm`). The `wasm-probe` script is the canonical verification of

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -7,7 +7,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "//": "NODE_OPTIONS=--experimental-wasm-modules is required because @tari-project/ootle-wasm@0.38.0 imports a .wasm file as an ES module and Node still gates that behind the flag (verified WASM probe outcome (b) — see README.md). Wired here so users never set it manually.",
+    "//": "NODE_OPTIONS=--experimental-wasm-modules is required because @tari-project/ootle-wasm@0.39.0 imports a .wasm file as an ES module and Node still gates that behind the flag (verified WASM probe outcome (b) — see README.md). Wired here so users never set it manually.",
     "wasm-probe": "NODE_OPTIONS=--experimental-wasm-modules tsx src/wasm-probe.ts",
     "balance-query": "NODE_OPTIONS=--experimental-wasm-modules tsx src/balance-query.ts",
     "counter-deploy": "NODE_OPTIONS=--experimental-wasm-modules tsx src/counter-deploy.ts",

--- a/examples/node/src/_common/faucet.ts
+++ b/examples/node/src/_common/faucet.ts
@@ -8,6 +8,7 @@ import {
   XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
   XTR_FAUCET_VAULT_ADDRESS,
   toHexStr,
+  resolveMaxEpoch,
 } from "@tari-project/ootle";
 import { IndexerProvider, PendingTransaction } from "@tari-project/ootle-indexer";
 import { DEFAULT_FAUCET_FEE, NETWORK, amountLiteralHex, firstNewSubstate, wait } from "@tari-project/example-common";
@@ -42,7 +43,7 @@ export async function faucet(
   const faucetAddress = options.faucetAddress ?? faucetComponentAddress();
   const ownerPublicKeyHex = toHexStr(await signer.secret.getPublicKey());
 
-  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK)
+  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withFeeInstructionsBuilder((b) =>
       b
         .createAccount(ownerPublicKeyHex)

--- a/examples/node/src/counter-deploy.ts
+++ b/examples/node/src/counter-deploy.ts
@@ -15,7 +15,7 @@
  * canonical example.
  */
 
-import { TransactionBuilder, getVaultIdsForAccount } from "@tari-project/ootle";
+import { TransactionBuilder, getVaultIdsForAccount, resolveMaxEpoch } from "@tari-project/ootle";
 import type {
   ComponentAddress,
   IndexerGetTransactionResultResponse,
@@ -59,7 +59,7 @@ await runScript(async () => {
 
   console.log(`\nBuilding deploy + increase chain on ${templateAddress} ...`);
   const senderVaults = await getVaultIdsForAccount(provider, sender);
-  const unsigned = new TransactionBuilder(NETWORK)
+  const unsigned = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: sender, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/dry-run.ts
+++ b/examples/node/src/dry-run.ts
@@ -20,7 +20,7 @@
  * **No `sendTransaction` is called** — no funds move either way.
  */
 
-import { TransactionBuilder, getVaultIdsForAccount } from "@tari-project/ootle";
+import { TransactionBuilder, getVaultIdsForAccount, resolveMaxEpoch } from "@tari-project/ootle";
 import type { ComponentAddress } from "@tari-project/ootle-ts-bindings";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
 import {
@@ -55,7 +55,7 @@ async function dryRunTransfer(
   // Declare the sender component and every vault it references as inputs — the
   // engine rejects with `vault_… not found` otherwise.
   const senderVaults = await getVaultIdsForAccount(provider, sender);
-  const builder = new TransactionBuilder(NETWORK)
+  const builder = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: sender, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/fungible-transfer.ts
+++ b/examples/node/src/fungible-transfer.ts
@@ -12,7 +12,7 @@
  * transfer transaction.
  */
 
-import { TransactionBuilder, getVaultIdsForAccount } from "@tari-project/ootle";
+import { TransactionBuilder, getVaultIdsForAccount, resolveMaxEpoch } from "@tari-project/ootle";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
 import {
   DEFAULT_FAUCET_FEE,
@@ -60,7 +60,7 @@ await runScript(async () => {
   // Declare the sender component + every vault it references (the engine
   // rejects `withdraw` with `vault_… not found` otherwise).
   const senderVaults = await getVaultIdsForAccount(provider, senderAccount);
-  const transferBuilder = new TransactionBuilder(NETWORK)
+  const transferBuilder = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: senderAccount, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/manual-co-signing.ts
+++ b/examples/node/src/manual-co-signing.ts
@@ -26,6 +26,7 @@ import {
   getVaultIdsForAccount,
   sealTransaction,
   signTransaction,
+  resolveMaxEpoch,
 } from "@tari-project/ootle";
 import type { Signer } from "@tari-project/ootle";
 import type { TransactionSignature, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
@@ -101,7 +102,7 @@ await runScript(async () => {
   console.log(`Sender account: ${senderAccount}`);
 
   const senderVaults = await getVaultIdsForAccount(provider, senderAccount);
-  const builder = new TransactionBuilder(NETWORK)
+  const builder = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: senderAccount, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/publish-template.ts
+++ b/examples/node/src/publish-template.ts
@@ -12,7 +12,7 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { AccountInvokeBuilder, getVaultIdsForAccount } from "@tari-project/ootle";
+import { AccountInvokeBuilder, getVaultIdsForAccount, resolveMaxEpoch } from "@tari-project/ootle";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
 import {
   NETWORK,
@@ -52,7 +52,7 @@ await runScript(async () => {
 
   // Declare the account and its vaults as inputs so the indexer resolves their versions.
   const senderVaults = await getVaultIdsForAccount(provider, account);
-  const unsigned = new AccountInvokeBuilder(NETWORK)
+  const unsigned = new AccountInvokeBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: account, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/stealth/_common.ts
+++ b/examples/node/src/stealth/_common.ts
@@ -41,6 +41,7 @@ import {
   signBalanceProof,
   stealthTransferInstruction,
   toHexStr,
+  resolveMaxEpoch,
 } from "@tari-project/ootle";
 import { IndexerProvider, PendingTransaction } from "@tari-project/ootle-indexer";
 import { DEFAULT_STEALTH_FAUCET_FEE } from "@tari-project/example-common";
@@ -138,7 +139,7 @@ export async function faucetStealth(
   const balanceProof = await signBalanceProof(crypto, Mask.zero(), outputMask, inputsStatement, outputsStatement);
   const statement = new StealthTransferStatement(inputsStatement, outputsStatement, balanceProof);
 
-  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK)
+  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withFeeInstructionsBuilder((b) =>
       b
         .createAccount(senderOwnerPublicKeyHex)

--- a/examples/node/src/template-invoke.ts
+++ b/examples/node/src/template-invoke.ts
@@ -33,6 +33,7 @@ import {
   intLiteral,
   resourceAddressLiteral,
   stringLiteral,
+  resolveMaxEpoch,
 } from "@tari-project/ootle";
 import type {
   ComponentAddress,
@@ -195,7 +196,7 @@ async function instantiateTemplate(
     throw new Error(`${mode.functionName} expects ${argTypes.length} arg(s), got ${mode.constructorArgs.length}`);
   }
   const args = mode.constructorArgs.map((raw, i) => coerceArg(raw, argTypes[i]));
-  const unsigned = new TransactionBuilder(NETWORK)
+  const unsigned = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: sender, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),
@@ -225,7 +226,7 @@ async function callRead(
   methodName: string,
 ): Promise<unknown> {
   const senderVaults = await getVaultIdsForAccount(provider, sender);
-  const unsigned = new TransactionBuilder(NETWORK)
+  const unsigned = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: sender, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),

--- a/examples/node/src/workspace-chain.ts
+++ b/examples/node/src/workspace-chain.ts
@@ -20,6 +20,7 @@ import {
   getVaultIdsForAccount,
   microTariLiteral,
   resourceAddressLiteral,
+  resolveMaxEpoch,
 } from "@tari-project/ootle";
 import type { IndexerGetTransactionResultResponse } from "@tari-project/ootle-ts-bindings";
 import { IndexerProvider } from "@tari-project/ootle-indexer";
@@ -64,7 +65,7 @@ await runScript(async () => {
 
   const senderVaults = await getVaultIdsForAccount(provider, senderAccount);
   const recipientVaults = await getVaultIdsForAccount(provider, recipientAccount);
-  const unsigned = new TransactionBuilder(NETWORK)
+  const unsigned = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withInputs([
       { substate_id: senderAccount, version: null },
       ...senderVaults.map((v) => ({ substate_id: v, version: null })),
@@ -121,7 +122,7 @@ await runScript(async () => {
 
 function printEvents(receipt: IndexerGetTransactionResultResponse): void {
   const result = receipt.result;
-  if (result === "Pending") return;
+  if (result === "Pending" || !("Finalized" in result)) return;
   const events = result.Finalized.execution_result?.finalize.events ?? [];
   console.log(`\nReceipt events (${events.length}):`);
   for (const event of events) {

--- a/examples/stealth-wallet/src/lib/stealth.ts
+++ b/examples/stealth-wallet/src/lib/stealth.ts
@@ -26,6 +26,7 @@ import {
   XTR_FAUCET_CLAIM_RESOURCE_ADDRESS,
   XTR_FAUCET_VAULT_ADDRESS,
   createOutput,
+  resolveMaxEpoch,
   sealTransaction,
   signBalanceProof,
   signTransaction,
@@ -115,7 +116,7 @@ export async function faucetStealth(
   const balanceProof = await signBalanceProof(crypto, Mask.zero(), outputMask, inputsStatement, outputsStatement);
   const statement = new StealthTransferStatement(inputsStatement, outputsStatement, balanceProof);
 
-  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK)
+  const unsigned: UnsignedTransactionV1 = new TransactionBuilder(NETWORK, await resolveMaxEpoch(provider))
     .withFeeInstructionsBuilder((b) =>
       b
         .createAccount(senderOwnerPublicKeyHex)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle.ts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript SDK for building on the Tari Ootle network",
   "homepage": "https://github.com/tari-project/ootle.ts#readme",
   "bugs": {

--- a/packages/ootle-indexer/package.json
+++ b/packages/ootle-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-indexer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tari-project/ootle.ts.git",

--- a/packages/ootle-indexer/src/indexer-provider.test.ts
+++ b/packages/ootle-indexer/src/indexer-provider.test.ts
@@ -92,3 +92,22 @@ describe("IndexerProvider.getStealthUtxo", () => {
     await expect(provider.getStealthUtxo(RESOURCE_ADDRESS, COMMITMENT)).rejects.toThrow("connection refused");
   });
 });
+
+describe("IndexerProvider.getCurrentEpoch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the epoch manager's current epoch", async () => {
+    const epochManagerStats = vi.fn().mockResolvedValue({ current_epoch: 1234 });
+    const client = {
+      identityGet: vi.fn().mockResolvedValue({}),
+      epochManagerStats,
+    };
+    vi.spyOn(IndexerClient, "usingFetchTransport").mockReturnValue(client as unknown as IndexerClient);
+    const provider = await IndexerProvider.connect({ url: "http://localhost:18300", network: Network.LocalNet });
+
+    await expect(provider.getCurrentEpoch()).resolves.toBe(1234);
+    expect(epochManagerStats).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ootle-indexer/src/indexer-provider.ts
+++ b/packages/ootle-indexer/src/indexer-provider.ts
@@ -87,6 +87,11 @@ export class IndexerProvider implements Provider {
     return this._network;
   }
 
+  public async getCurrentEpoch(): Promise<number> {
+    const stats = await this.client.epochManagerStats();
+    return stats.current_epoch;
+  }
+
   public async getSubstate(substateId: string, version: number | null = null): Promise<IndexerGetSubstateResponse> {
     return this.client.substatesGet(substateId, {
       version,

--- a/packages/ootle-secret-key-wallet/package.json
+++ b/packages/ootle-secret-key-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-secret-key-wallet",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tari-project/ootle.ts.git",

--- a/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.test.ts
+++ b/packages/ootle-secret-key-wallet/src/ephemeral-key-signer.test.ts
@@ -10,12 +10,12 @@ import { describe, expect, it } from "vitest";
 import { InvalidArgumentError, TransactionBuilder, fromHexStr, toHexStr } from "@tari-project/ootle";
 import { generateKeypair } from "@tari-project/ootle-wasm";
 import { EphemeralKeySigner } from "./ephemeral-key-signer";
-import { TEST_NETWORK } from "./test/fixtures";
+import { TEST_MAX_EPOCH, TEST_NETWORK } from "./test/fixtures";
 
 const HEX_64 = /^[0-9a-f]{64}$/;
 
 function trivialUnsignedTx() {
-  return TransactionBuilder.new(TEST_NETWORK).dropAllProofsInWorkspace().buildUnsignedTransaction();
+  return TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).dropAllProofsInWorkspace().buildUnsignedTransaction();
 }
 
 describe("EphemeralKeySigner.generate", () => {

--- a/packages/ootle-secret-key-wallet/src/secret-key-wallet.stealth.test.ts
+++ b/packages/ootle-secret-key-wallet/src/secret-key-wallet.stealth.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@tari-project/ootle-wasm";
 import { TransactionBuilder } from "@tari-project/ootle";
 import { SecretKeyWallet } from "./secret-key-wallet";
-import { TEST_NETWORK } from "./test/fixtures";
+import { TEST_MAX_EPOCH, TEST_NETWORK } from "./test/fixtures";
 
 const HEX_64 = /^[0-9a-f]{64}$/;
 
@@ -42,7 +42,9 @@ const cryptoCtx = {
  * a hand-written literal) so its JSON carries every field `hashUnsignedTransaction` requires.
  */
 function makeUnsignedJson(): string {
-  const unsignedTx = TransactionBuilder.new(TEST_NETWORK).dropAllProofsInWorkspace().buildUnsignedTransaction();
+  const unsignedTx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
+    .dropAllProofsInWorkspace()
+    .buildUnsignedTransaction();
   return JSON.stringify(unsignedTx);
 }
 

--- a/packages/ootle-secret-key-wallet/src/secret-key-wallet.test.ts
+++ b/packages/ootle-secret-key-wallet/src/secret-key-wallet.test.ts
@@ -16,12 +16,12 @@ import {
   publicKeyFromSecretKey,
 } from "@tari-project/ootle-wasm";
 import { SecretKeyWallet } from "./secret-key-wallet";
-import { TEST_NETWORK } from "./test/fixtures";
+import { TEST_MAX_EPOCH, TEST_NETWORK } from "./test/fixtures";
 
 const HEX_64 = /^[0-9a-f]{64}$/;
 
 function trivialUnsignedTx() {
-  return TransactionBuilder.new(TEST_NETWORK).dropAllProofsInWorkspace().buildUnsignedTransaction();
+  return TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).dropAllProofsInWorkspace().buildUnsignedTransaction();
 }
 
 describe("SecretKeyWallet.randomWithViewKey", () => {

--- a/packages/ootle-secret-key-wallet/src/test/fixtures.ts
+++ b/packages/ootle-secret-key-wallet/src/test/fixtures.ts
@@ -17,3 +17,9 @@ import { Network } from "@tari-project/ootle";
 
 /** The network byte every wallet test uses unless it explicitly varies it. */
 export const TEST_NETWORK = Network.LocalNet;
+
+/**
+ * The `max_epoch` every wallet test uses. `max_epoch` is mandatory on
+ * `UnsignedTransactionV1`, so every `TransactionBuilder` needs one.
+ */
+export const TEST_MAX_EPOCH = 100;

--- a/packages/ootle-wallet-daemon-signer/package.json
+++ b/packages/ootle-wallet-daemon-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle-wallet-daemon-signer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tari-project/ootle.ts.git",

--- a/packages/ootle/package.json
+++ b/packages/ootle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/ootle",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tari-project/ootle.ts.git",

--- a/packages/ootle/src/builder.adopt.test.ts
+++ b/packages/ootle/src/builder.adopt.test.ts
@@ -28,7 +28,7 @@ import { describe, expect, it } from "vitest";
 import type { Instruction, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
 import { TransactionBuilder } from "./builder";
 import { FaucetInvokeBuilder } from "./builtin-templates";
-import { TEST_ACCOUNT_ADDRESS, TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS } from "./test/fixtures";
+import { TEST_ACCOUNT_ADDRESS, TEST_MAX_EPOCH, TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS } from "./test/fixtures";
 
 const TEMPLATE_ADDRESS = "template_" + "ab".repeat(32);
 
@@ -56,30 +56,30 @@ function writtenSlots(instructions: Instruction[]): number[] {
 
 describe("withUnsignedTransaction — copy on adopt", () => {
   it("does not mutate the adopted transaction's instructions", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK)
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .buildUnsignedTransaction();
     const before = [...adopted.instructions];
 
-    TransactionBuilder.new(TEST_NETWORK).withUnsignedTransaction(adopted).dropAllProofsInWorkspace();
+    TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withUnsignedTransaction(adopted).dropAllProofsInWorkspace();
 
     expect(adopted.instructions).toEqual(before);
   });
 
   it("does not mutate the adopted transaction's blobs", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
     expect(adopted.blobs).toEqual([]);
 
-    TransactionBuilder.new(TEST_NETWORK).withUnsignedTransaction(adopted).publishTemplate("QUJD");
+    TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withUnsignedTransaction(adopted).publishTemplate("QUJD");
 
     expect(adopted.blobs).toEqual([]);
   });
 
   it("does not mutate the adopted transaction's fee_instructions", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
     const before = [...adopted.fee_instructions];
 
-    TransactionBuilder.new(TEST_NETWORK)
+    TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1_000n);
 
@@ -87,10 +87,10 @@ describe("withUnsignedTransaction — copy on adopt", () => {
   });
 
   it("does not mutate the adopted transaction's inputs", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
     const before = [...adopted.inputs];
 
-    TransactionBuilder.new(TEST_NETWORK)
+    TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .withInputs([{ substate_id: TEST_ACCOUNT_ADDRESS, version: null }]);
 
@@ -100,12 +100,12 @@ describe("withUnsignedTransaction — copy on adopt", () => {
   it("keeps a serialized snapshot of the adopted transaction valid (the co-signing flow)", () => {
     // The failure this guards: a co-signer serializes `adopted`, the local builder keeps
     // building, and the two sides now hash different transactions.
-    const adopted = TransactionBuilder.new(TEST_NETWORK)
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .buildUnsignedTransaction();
     const snapshot = JSON.stringify(adopted);
 
-    TransactionBuilder.new(TEST_NETWORK)
+    TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("bucket")
       .publishTemplate("QUJD")
@@ -118,12 +118,12 @@ describe("withUnsignedTransaction — copy on adopt", () => {
 describe("withUnsignedTransaction — workspace slot allocation", () => {
   it("does not re-issue a workspace slot the adopted transaction already occupies", () => {
     // The faucet builder emits `PutLastInstructionOutputOnWorkspace { key: 0 }`.
-    const adopted = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+    const adopted = new FaucetInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH, XTR_FAUCET_COMPONENT_ADDRESS)
       .takeMaxFaucetFunds(TEST_ACCOUNT_ADDRESS)
       .build();
     expect(writtenSlots(adopted.instructions)).toEqual([0]);
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .callMethod({ componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "noop" }, [])
       .saveVar("bucket")
@@ -137,14 +137,14 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
     // Slots 3 and 1 occupied out of order, so the seed has to come from the max rather
     // than from a count or from the last instruction.
     const adopted: UnsignedTransactionV1 = {
-      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      ...TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction(),
       instructions: [
         { PutLastInstructionOutputOnWorkspace: { key: 3 } },
         { PutLastInstructionOutputOnWorkspace: { key: 1 } },
       ],
     };
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("next")
       .buildUnsignedTransaction();
@@ -157,12 +157,12 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
     // claimed by a fee instruction must NOT push the main counter along (and vice versa).
     // Rust models this as a separate fee-instruction builder with its own WorkspaceIds.
     const adopted: UnsignedTransactionV1 = {
-      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      ...TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction(),
       fee_instructions: [{ PutLastInstructionOutputOnWorkspace: { key: 5 } }],
       instructions: [],
     };
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("next")
       .buildUnsignedTransaction();
@@ -175,7 +175,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
   it("counts TakeFromBucket output_bucket as an allocation", () => {
     // The third allocator in Rust's `allocated_workspace_id`; `input_bucket` only reads.
     const adopted: UnsignedTransactionV1 = {
-      ...TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction(),
+      ...TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction(),
       instructions: [
         {
           TakeFromBucket: {
@@ -187,7 +187,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
       ],
     };
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("next")
       .buildUnsignedTransaction();
@@ -198,7 +198,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
   it("addInstruction accounts for a pre-built instruction's slot (as Rust's add_instruction does)", () => {
     // Not an adopt path: slots that arrive through the public escape hatches must be
     // accounted for too, or the next saveVar collides with them.
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .addInstruction({ PutLastInstructionOutputOnWorkspace: { key: 2 } })
       .saveVar("next")
       .buildUnsignedTransaction();
@@ -207,7 +207,7 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
   });
 
   it("withInstructions accounts for pre-built slots too", () => {
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withInstructions([
         { PutLastInstructionOutputOnWorkspace: { key: 0 } },
         { AllocateAddress: { allocatable_type: "Component", workspace_id: 7 } },
@@ -219,12 +219,12 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
   });
 
   it("counts AllocateAddress workspace ids as occupied", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK)
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .allocateAddress("Component", "addr")
       .buildUnsignedTransaction();
     expect(writtenSlots(adopted.instructions)).toEqual([0]);
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("bucket")
       .buildUnsignedTransaction();
@@ -233,11 +233,11 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
   });
 
   it("still starts at 0 when the adopted transaction occupies no slots", () => {
-    const adopted = TransactionBuilder.new(TEST_NETWORK)
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .buildUnsignedTransaction();
 
-    const out = TransactionBuilder.new(TEST_NETWORK)
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withUnsignedTransaction(adopted)
       .saveVar("bucket")
       .buildUnsignedTransaction();
@@ -247,10 +247,10 @@ describe("withUnsignedTransaction — workspace slot allocation", () => {
 
   it("still clears the name→id mapping, so adopted names are not resolvable", () => {
     // Unchanged behaviour: names are not recoverable from the wire form, only slots are.
-    const builder = TransactionBuilder.new(TEST_NETWORK)
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .saveVar("a");
-    builder.withUnsignedTransaction(TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction());
+    builder.withUnsignedTransaction(TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction());
 
     expect(() => builder.resolveWorkspaceOffsetId("a")).toThrow('No workspace variable named "a" has been defined');
   });

--- a/packages/ootle/src/builder.test.ts
+++ b/packages/ootle/src/builder.test.ts
@@ -9,32 +9,39 @@
 
 import { describe, expect, it } from "vitest";
 import type { ConfidentialWithdrawProof, Instruction } from "@tari-project/ootle-ts-bindings";
-import { TransactionBuilder } from "./builder";
+import {
+  DEFAULT_TRANSACTION_VALIDITY_EPOCHS,
+  MAX_TRANSACTION_VALIDITY_EPOCHS,
+  TransactionBuilder,
+  resolveMaxEpoch,
+} from "./builder";
+import { fakeProvider } from "./test/fake-provider";
 import { resourceAddressLiteral } from "./helpers/cbor-literal";
 import { Network } from "./network";
-import { TEST_ACCOUNT_ADDRESS, TEST_NETWORK, XTR_RESOURCE } from "./test/fixtures";
+import { TEST_ACCOUNT_ADDRESS, TEST_MAX_EPOCH, TEST_NETWORK, XTR_RESOURCE } from "./test/fixtures";
 
 const TEMPLATE_ADDRESS = "template_" + "11".repeat(32);
 const OWNER_PUBLIC_KEY = "aa".repeat(32);
 
 describe("TransactionBuilder.buildUnsignedTransaction", () => {
   it("returns the canonical empty shape for a fresh builder", () => {
-    const tx = TransactionBuilder.new(Network.LocalNet).buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(Network.LocalNet, TEST_MAX_EPOCH).buildUnsignedTransaction();
     expect(tx).toEqual({
       network: Network.LocalNet,
       fee_instructions: [],
       instructions: [],
       inputs: [],
       min_epoch: null,
-      max_epoch: null,
+      max_epoch: TEST_MAX_EPOCH,
       dry_run: false,
       is_seal_signer_authorized: false,
       blobs: [],
+      nonce: 0,
     });
   });
 
   it("returns fresh arrays on each call so callers can mutate without leaking back", () => {
-    const builder = TransactionBuilder.new(TEST_NETWORK).dropAllProofsInWorkspace();
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).dropAllProofsInWorkspace();
     const first = builder.buildUnsignedTransaction();
     first.instructions.push("DropAllProofsInWorkspace");
     const second = builder.buildUnsignedTransaction();
@@ -44,13 +51,13 @@ describe("TransactionBuilder.buildUnsignedTransaction", () => {
 
 describe("TransactionBuilder.publishTemplate", () => {
   it("stores the binary as a blob and references it by index (not inline)", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK).publishTemplate("QUJD").buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).publishTemplate("QUJD").buildUnsignedTransaction();
     expect(tx.blobs).toEqual(["QUJD"]);
     expect(tx.instructions).toEqual([{ PublishTemplate: { binary: 0, metadata_hash: null } }]);
   });
 
   it("assigns sequential blob indices and threads the optional metadata hash", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .publishTemplate("Zmlyc3Q=")
       .publishTemplate("c2Vjb25k", "0x1234")
       .buildUnsignedTransaction();
@@ -64,7 +71,7 @@ describe("TransactionBuilder.publishTemplate", () => {
 
 describe("TransactionBuilder.callFunction", () => {
   it("emits a CallFunction instruction with the bare Hash32 address, function, and resolved args", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [{ Literal: "42" }])
       .buildUnsignedTransaction();
     expect(tx.instructions).toEqual([
@@ -81,7 +88,7 @@ describe("TransactionBuilder.callFunction", () => {
 
 describe("TransactionBuilder.callMethod", () => {
   it("emits a CallMethod with an Address call when componentAddress is given", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callMethod({ componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "withdraw" }, [{ Literal: XTR_RESOURCE }])
       .buildUnsignedTransaction();
     expect(tx.instructions).toEqual([
@@ -96,7 +103,7 @@ describe("TransactionBuilder.callMethod", () => {
   });
 
   it("emits a CallMethod with a Workspace call when fromWorkspace is given", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .saveVar("acct")
       .callMethod({ fromWorkspace: "acct", methodName: "deposit" }, [])
@@ -106,7 +113,7 @@ describe("TransactionBuilder.callMethod", () => {
   });
 
   it("throws when neither componentAddress nor fromWorkspace is supplied", () => {
-    const builder = TransactionBuilder.new(TEST_NETWORK);
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH);
     expect(() => builder.callMethod({ methodName: "withdraw" } as { methodName: string }, [])).toThrow(
       /callMethod requires either `componentAddress` or `fromWorkspace`/,
     );
@@ -115,7 +122,7 @@ describe("TransactionBuilder.callMethod", () => {
 
 describe("TransactionBuilder workspace state machine", () => {
   it("resolves a Workspace-arg by name after saveVar", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .saveVar("bucket")
       .callMethod({ componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "deposit" }, [{ Workspace: "bucket" }])
@@ -126,7 +133,7 @@ describe("TransactionBuilder workspace state machine", () => {
 
   it("throws when a Workspace arg references an undefined name", () => {
     expect(() =>
-      TransactionBuilder.new(TEST_NETWORK).callMethod(
+      TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).callMethod(
         { componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "deposit" },
         [{ Workspace: "ghost" }],
       ),
@@ -135,12 +142,15 @@ describe("TransactionBuilder workspace state machine", () => {
 
   it("throws when callMethod fromWorkspace references an undefined name", () => {
     expect(() =>
-      TransactionBuilder.new(TEST_NETWORK).callMethod({ fromWorkspace: "ghost", methodName: "deposit" }, []),
+      TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).callMethod(
+        { fromWorkspace: "ghost", methodName: "deposit" },
+        [],
+      ),
     ).toThrow('No workspace variable named "ghost" has been defined');
   });
 
   it("resolveWorkspaceOffsetId returns id + offset for dot-notation keys", () => {
-    const builder = TransactionBuilder.new(TEST_NETWORK)
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .saveVar("bucket");
     expect(builder.resolveWorkspaceOffsetId("bucket")).toEqual({ id: 0, offset: null });
@@ -148,17 +158,17 @@ describe("TransactionBuilder workspace state machine", () => {
   });
 
   it("resolveWorkspaceOffsetId throws when the name was never saved", () => {
-    expect(() => TransactionBuilder.new(TEST_NETWORK).resolveWorkspaceOffsetId("ghost")).toThrow(
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).resolveWorkspaceOffsetId("ghost")).toThrow(
       'No workspace variable named "ghost" has been defined',
     );
   });
 
   it("withUnsignedTransaction resets the workspace state", () => {
-    const builder = TransactionBuilder.new(TEST_NETWORK)
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .callFunction({ templateAddress: TEMPLATE_ADDRESS, functionName: "new" }, [])
       .saveVar("a");
     // Re-import the empty UnsignedTransactionV1 — this should clear named ids.
-    const empty = TransactionBuilder.new(TEST_NETWORK).buildUnsignedTransaction();
+    const empty = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
     builder.withUnsignedTransaction(empty);
     expect(() => builder.resolveWorkspaceOffsetId("a")).toThrow('No workspace variable named "a" has been defined');
   });
@@ -166,7 +176,7 @@ describe("TransactionBuilder workspace state machine", () => {
 
 describe("TransactionBuilder fee instructions", () => {
   it("feeTransactionPayFromComponent emits a pay_fee CallMethod with a BOR-CBOR hex Literal max-fee", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1234n)
       .buildUnsignedTransaction();
     expect(tx.fee_instructions).toEqual([
@@ -174,24 +184,27 @@ describe("TransactionBuilder fee instructions", () => {
         CallMethod: {
           call: { Address: TEST_ACCOUNT_ADDRESS },
           method: "pay_fee",
-          args: [{ Literal: "821904d200" }],
+          args: [{ Literal: "1904d2" }],
         },
       },
     ]);
   });
 
-  it("feeTransactionPayFromComponent routes µTari through amountLiteral (CBOR [lo_u64, hi_u64])", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+  it("feeTransactionPayFromComponent routes µTari through amountLiteral (bare CBOR integer)", () => {
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1234n)
       .buildUnsignedTransaction();
     const arg = (tx.fee_instructions[0] as { CallMethod: { args: unknown[] } }).CallMethod.args[0];
-    expect(arg).toEqual({ Literal: "821904d200" });
+    expect(arg).toEqual({ Literal: "1904d2" });
   });
 
   it("feeTransactionPayFromComponentConfidential throws (proof BOR encoding is unimplemented)", () => {
     const proof = {} as unknown as ConfidentialWithdrawProof;
     expect(() =>
-      TransactionBuilder.new(TEST_NETWORK).feeTransactionPayFromComponentConfidential(TEST_ACCOUNT_ADDRESS, proof),
+      TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).feeTransactionPayFromComponentConfidential(
+        TEST_ACCOUNT_ADDRESS,
+        proof,
+      ),
     ).toThrow(/not implemented/);
   });
 });
@@ -200,7 +213,7 @@ describe("TransactionBuilder bulk operations and metadata", () => {
   it("withInstructions appends to instructions in order", () => {
     const a: Instruction = "DropAllProofsInWorkspace";
     const b: Instruction = "DropAllProofsInWorkspace";
-    const tx = TransactionBuilder.new(TEST_NETWORK).withInstructions([a, b]).buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withInstructions([a, b]).buildUnsignedTransaction();
     expect(tx.instructions).toEqual([a, b]);
   });
 
@@ -212,12 +225,14 @@ describe("TransactionBuilder bulk operations and metadata", () => {
         args: [{ Literal: "1" }],
       },
     };
-    const tx = TransactionBuilder.new(TEST_NETWORK).withFeeInstructions([fee, fee]).buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
+      .withFeeInstructions([fee, fee])
+      .buildUnsignedTransaction();
     expect(tx.fee_instructions).toEqual([fee, fee]);
   });
 
   it("withFeeInstructionsBuilder copies the inner builder's instructions into fee_instructions", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withFeeInstructionsBuilder((b) =>
         b.callMethod({ componentAddress: TEST_ACCOUNT_ADDRESS, methodName: "pay_fee" }, [{ Literal: "100" }]),
       )
@@ -236,7 +251,7 @@ describe("TransactionBuilder bulk operations and metadata", () => {
 
   it("withInputs / withMinEpoch / withMaxEpoch set the corresponding fields", () => {
     const inputs = [{ substate_id: "component_x", version: 1 }];
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .withInputs(inputs)
       .withMinEpoch(10)
       .withMaxEpoch(20)
@@ -247,12 +262,16 @@ describe("TransactionBuilder bulk operations and metadata", () => {
   });
 
   it("dropAllProofsInWorkspace emits the bare-string instruction (not an object)", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK).dropAllProofsInWorkspace().buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
+      .dropAllProofsInWorkspace()
+      .buildUnsignedTransaction();
     expect(tx.instructions).toEqual(["DropAllProofsInWorkspace"]);
   });
 
   it("createAccount emits a CreateAccount instruction with the supplied owner public key", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK).createAccount(OWNER_PUBLIC_KEY).buildUnsignedTransaction();
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
+      .createAccount(OWNER_PUBLIC_KEY)
+      .buildUnsignedTransaction();
     expect(tx.instructions).toEqual([
       {
         CreateAccount: {
@@ -266,7 +285,7 @@ describe("TransactionBuilder bulk operations and metadata", () => {
   });
 
   it("createProof emits a create_proof_for_resource CallMethod", () => {
-    const tx = TransactionBuilder.new(TEST_NETWORK)
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
       .createProof(TEST_ACCOUNT_ADDRESS, XTR_RESOURCE)
       .buildUnsignedTransaction();
     expect(tx.instructions).toEqual([
@@ -281,7 +300,7 @@ describe("TransactionBuilder bulk operations and metadata", () => {
   });
 
   it("allocateAddress emits an AllocateAddress and reserves the workspace id", () => {
-    const builder = TransactionBuilder.new(TEST_NETWORK).allocateAddress("Component", "alloc");
+    const builder = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).allocateAddress("Component", "alloc");
     const tx = builder.buildUnsignedTransaction();
     expect(tx.instructions).toEqual([
       {
@@ -290,5 +309,98 @@ describe("TransactionBuilder bulk operations and metadata", () => {
     ]);
     // The name is reachable via resolveWorkspaceOffsetId, proving the id was reserved.
     expect(builder.resolveWorkspaceOffsetId("alloc")).toEqual({ id: 0, offset: null });
+  });
+});
+
+describe("TransactionBuilder validity window and nonce", () => {
+  it("carries the maxEpoch passed to the constructor", () => {
+    const tx = TransactionBuilder.new(TEST_NETWORK, 4242).buildUnsignedTransaction();
+    expect(tx.max_epoch).toBe(4242);
+  });
+
+  it.each([-1, 1.5, Number.NaN])("rejects %s as a maxEpoch", (bad) => {
+    expect(() => TransactionBuilder.new(TEST_NETWORK, bad)).toThrow(/non-negative integer epoch/);
+  });
+
+  it("withMaxEpoch overrides the constructor's window", () => {
+    const tx = TransactionBuilder.new(TEST_NETWORK, 100).withMaxEpoch(200).buildUnsignedTransaction();
+    expect(tx.max_epoch).toBe(200);
+  });
+
+  it("withMinEpoch rejects a non-integer epoch", () => {
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withMinEpoch(-3)).toThrow(
+      /non-negative integer epoch/,
+    );
+  });
+
+  it("defaults the nonce to 0", () => {
+    expect(TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction().nonce).toBe(0);
+  });
+
+  it("withNonce accepts a number and a bigint", () => {
+    expect(TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(7).buildUnsignedTransaction().nonce).toBe(7);
+    expect(TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(7n).buildUnsignedTransaction().nonce).toBe(7);
+  });
+
+  it("keeps a nonce above Number.MAX_SAFE_INTEGER as a bigint so it survives serialization", () => {
+    const big = 2n ** 64n - 1n;
+    const tx = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(big).buildUnsignedTransaction();
+    expect(tx.nonce).toBe(big);
+  });
+
+  it("rejects a nonce outside u64", () => {
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(-1)).toThrow(/unsigned 64-bit/);
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(2n ** 64n)).toThrow(/unsigned 64-bit/);
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withNonce(1.5)).toThrow(/must be an integer/);
+  });
+
+  it("withUnsignedTransaction defaults a nonce absent from a JSON-crossed transaction", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
+    // Simulate a wire value produced before `nonce` existed.
+    delete (adopted as { nonce?: unknown }).nonce;
+    const out = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH)
+      .withUnsignedTransaction(adopted)
+      .buildUnsignedTransaction();
+    expect(out.nonce).toBe(0);
+  });
+
+  it("withUnsignedTransaction refuses a transaction with no max_epoch", () => {
+    const adopted = TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).buildUnsignedTransaction();
+    (adopted as { max_epoch: unknown }).max_epoch = null;
+    expect(() => TransactionBuilder.new(TEST_NETWORK, TEST_MAX_EPOCH).withUnsignedTransaction(adopted)).toThrow(
+      /max_epoch must be a non-negative integer epoch/,
+    );
+  });
+
+  it("withFeeInstructionsBuilder gives the nested builder the same window", () => {
+    const tx = TransactionBuilder.new(TEST_NETWORK, 777)
+      .withFeeInstructionsBuilder((b) => b.dropAllProofsInWorkspace())
+      .buildUnsignedTransaction();
+    expect(tx.max_epoch).toBe(777);
+    expect(tx.fee_instructions).toEqual(["DropAllProofsInWorkspace"]);
+  });
+});
+
+describe("resolveMaxEpoch", () => {
+  it("adds the default lead to the provider's current epoch", async () => {
+    const provider = fakeProvider({ getCurrentEpoch: async () => 500 });
+    expect(await resolveMaxEpoch(provider)).toBe(500 + DEFAULT_TRANSACTION_VALIDITY_EPOCHS);
+  });
+
+  it("honours an explicit lead", async () => {
+    const provider = fakeProvider({ getCurrentEpoch: async () => 500 });
+    expect(await resolveMaxEpoch(provider, 3)).toBe(503);
+  });
+
+  it("rejects a lead beyond the network's maximum validity window", async () => {
+    const provider = fakeProvider({ getCurrentEpoch: async () => 500 });
+    await expect(resolveMaxEpoch(provider, MAX_TRANSACTION_VALIDITY_EPOCHS + 1)).rejects.toThrow(
+      /exceeds the network's maximum validity window/,
+    );
+  });
+
+  it("rejects a non-positive lead", async () => {
+    const provider = fakeProvider({ getCurrentEpoch: async () => 500 });
+    await expect(resolveMaxEpoch(provider, 0)).rejects.toThrow(/positive integer/);
   });
 });

--- a/packages/ootle/src/builder.ts
+++ b/packages/ootle/src/builder.ts
@@ -20,6 +20,61 @@ import { microTariLiteral } from "./helpers/amount";
 import { resourceAddressLiteral } from "./helpers/cbor-literal";
 import { parseWorkspaceStringKey } from "./helpers/workspace";
 import { InvalidArgumentError } from "./errors";
+import type { Provider } from "./provider";
+
+/**
+ * The longest validity window any network accepts, in epochs
+ * (`ConsensusConstants::max_transaction_validity_epochs`, ~30 days). A transaction whose
+ * `max_epoch` sits further ahead of the current epoch than this is aborted with
+ * `AbortReason::ValidityWindowTooLong`.
+ */
+export const MAX_TRANSACTION_VALIDITY_EPOCHS = 2160;
+
+/**
+ * The validity window {@link resolveMaxEpoch} applies when the caller does not name one.
+ * Ten epochs is comfortably longer than a transaction takes to finalize while still
+ * letting a stuck transaction die on its own rather than lingering as a resubmittable
+ * intent.
+ */
+export const DEFAULT_TRANSACTION_VALIDITY_EPOCHS = 10;
+
+/**
+ * Reads the chain tip and returns the `max_epoch` a transaction built now should carry:
+ * `currentEpoch + leadEpochs`.
+ *
+ * ```ts
+ * const builder = TransactionBuilder.new(provider.network(), await resolveMaxEpoch(provider));
+ * ```
+ *
+ * @throws {InvalidArgumentError} if `leadEpochs` is not a positive integer, or exceeds
+ *   {@link MAX_TRANSACTION_VALIDITY_EPOCHS} (which the network would reject with
+ *   `AbortReason::ValidityWindowTooLong`).
+ */
+export async function resolveMaxEpoch(
+  provider: Provider,
+  leadEpochs: number = DEFAULT_TRANSACTION_VALIDITY_EPOCHS,
+): Promise<number> {
+  if (!Number.isInteger(leadEpochs) || leadEpochs < 1) {
+    throw new InvalidArgumentError(`resolveMaxEpoch: leadEpochs must be a positive integer, got ${leadEpochs}`);
+  }
+  if (leadEpochs > MAX_TRANSACTION_VALIDITY_EPOCHS) {
+    throw new InvalidArgumentError(
+      `resolveMaxEpoch: leadEpochs ${leadEpochs} exceeds the network's maximum validity window of ` +
+        `${MAX_TRANSACTION_VALIDITY_EPOCHS} epochs`,
+    );
+  }
+  return (await provider.getCurrentEpoch()) + leadEpochs;
+}
+
+const U64_MAX = (1n << 64n) - 1n;
+
+/** @throws {InvalidArgumentError} if `epoch` is not a non-negative integer. */
+function assertEpoch(epoch: number, name: string): number {
+  if (!Number.isInteger(epoch) || epoch < 0) {
+    throw new InvalidArgumentError(`${name} must be a non-negative integer epoch, got ${epoch}`);
+  }
+  return epoch;
+}
 
 /**
  * Strip the `template_` prefix to the bare `Hash32` hex the `CallFunction`
@@ -169,24 +224,35 @@ export class TransactionBuilder {
   private workspaceIds: WorkspaceIds;
   private feeWorkspaceIds: WorkspaceIds;
 
-  constructor(network: Network | number) {
+  /**
+   * `maxEpoch` is required: every transaction now carries a bounded validity window
+   * (`UnsignedTransactionV1.max_epoch`), so the last epoch in which it may be sequenced
+   * is decided up front rather than left open. The network rejects a window longer than
+   * {@link MAX_TRANSACTION_VALIDITY_EPOCHS} epochs past the current one with
+   * `AbortReason::ValidityWindowTooLong`, so derive it from the chain tip — e.g.
+   * `(await provider.getCurrentEpoch()) + 10`.
+   *
+   * @throws {InvalidArgumentError} if `maxEpoch` is not a non-negative integer.
+   */
+  constructor(network: Network | number, maxEpoch: number) {
     this.unsignedTransaction = {
       network: network,
       fee_instructions: [],
       instructions: [],
       inputs: [],
       min_epoch: null,
-      max_epoch: null,
+      max_epoch: assertEpoch(maxEpoch, "maxEpoch"),
       dry_run: false,
       is_seal_signer_authorized: false,
       blobs: [],
+      nonce: 0,
     };
     this.workspaceIds = new WorkspaceIds();
     this.feeWorkspaceIds = new WorkspaceIds();
   }
 
-  public static new(network: Network | number): TransactionBuilder {
-    return new TransactionBuilder(network);
+  public static new(network: Network | number, maxEpoch: number): TransactionBuilder {
+    return new TransactionBuilder(network, maxEpoch);
   }
 
   public callFunction<T extends TariFunctionDefinition>(func: T, args: Exclude<T["args"], undefined>): this {
@@ -369,7 +435,7 @@ export class TransactionBuilder {
    * Note this REPLACES any fee instructions already set, as it always has.
    */
   public withFeeInstructionsBuilder(builder: (b: TransactionBuilder) => TransactionBuilder): this {
-    const inner = builder(new TransactionBuilder(this.unsignedTransaction.network));
+    const inner = builder(new TransactionBuilder(this.unsignedTransaction.network, this.unsignedTransaction.max_epoch));
     this.unsignedTransaction.fee_instructions = inner.unsignedTransaction.instructions;
     // Adopt the nested builder's slot accounting so later `addFeeInstruction` calls on the
     // outer builder cannot re-issue a slot the nested one already claimed.
@@ -387,13 +453,44 @@ export class TransactionBuilder {
     return this;
   }
 
+  /** @throws {InvalidArgumentError} if `minEpoch` is not a non-negative integer. */
   public withMinEpoch(minEpoch: number): this {
-    this.unsignedTransaction.min_epoch = minEpoch;
+    this.unsignedTransaction.min_epoch = assertEpoch(minEpoch, "minEpoch");
     return this;
   }
 
+  /**
+   * Overrides the validity window set at construction. See the constructor for the
+   * network's cap on how far ahead of the current epoch this may sit.
+   *
+   * @throws {InvalidArgumentError} if `maxEpoch` is not a non-negative integer.
+   */
   public withMaxEpoch(maxEpoch: number): this {
-    this.unsignedTransaction.max_epoch = maxEpoch;
+    this.unsignedTransaction.max_epoch = assertEpoch(maxEpoch, "maxEpoch");
+    return this;
+  }
+
+  /**
+   * Stamps the transaction nonce, which distinguishes otherwise-identical transactions.
+   *
+   * The transaction id excludes the seal signature's witness data, so two identical
+   * bodies sealed by the same key are the *same* transaction — submitting both executes
+   * once. Give each intent a distinct nonce when repeated submissions must each execute.
+   * Defaults to `0`.
+   *
+   * @throws {InvalidArgumentError} if `nonce` is negative or overflows u64.
+   */
+  public withNonce(nonce: number | bigint): this {
+    if (typeof nonce === "number" && !Number.isInteger(nonce)) {
+      throw new InvalidArgumentError(`withNonce: nonce must be an integer, got ${nonce}`);
+    }
+    const value = typeof nonce === "bigint" ? nonce : BigInt(nonce);
+    if (value < 0n || value > U64_MAX) {
+      throw new InvalidArgumentError(`withNonce: nonce must fit an unsigned 64-bit integer, got ${nonce}`);
+    }
+    // Kept as a `bigint` above `Number.MAX_SAFE_INTEGER` so `serializeUnsignedTx` can emit
+    // it losslessly as a JSON string; smaller values stay bare numbers, as they always were.
+    this.unsignedTransaction.nonce = value > BigInt(Number.MAX_SAFE_INTEGER) ? value : Number(value);
     return this;
   }
 
@@ -408,14 +505,18 @@ export class TransactionBuilder {
    * This mirrors the copy {@link buildUnsignedTransaction} makes on the way out.
    */
   public withUnsignedTransaction(unsignedTransaction: UnsignedTransactionV1): this {
-    // `blobs` is required on the binding type but may still be absent on a value that
-    // crossed a JSON boundary (the wire struct defaults it), so keep the fallback.
+    // `blobs` and `nonce` are required on the binding type but may still be absent on a
+    // value that crossed a JSON boundary (the wire struct defaults both), so keep the
+    // fallbacks. `max_epoch` has no default — a transaction without one is not valid, so
+    // adopting one is a caller error rather than something to paper over.
     this.unsignedTransaction = {
       ...unsignedTransaction,
       instructions: [...unsignedTransaction.instructions],
       fee_instructions: [...unsignedTransaction.fee_instructions],
       inputs: [...unsignedTransaction.inputs],
       blobs: [...(unsignedTransaction.blobs ?? [])],
+      nonce: unsignedTransaction.nonce ?? 0,
+      max_epoch: assertEpoch(unsignedTransaction.max_epoch, "withUnsignedTransaction: max_epoch"),
     };
     // Workspace *names* are not recoverable from the wire form, so the name → id mapping
     // starts empty and adopted buckets stay unaddressable by name (as before). The *slots*

--- a/packages/ootle/src/builtin-templates.test.ts
+++ b/packages/ootle/src/builtin-templates.test.ts
@@ -9,13 +9,19 @@
 import { describe, expect, it } from "vitest";
 import { AccountInvokeBuilder, FaucetInvokeBuilder } from "./builtin-templates";
 import { resourceAddressLiteral } from "./helpers/cbor-literal";
-import { TEST_ACCOUNT_ADDRESS, TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS, XTR_RESOURCE } from "./test/fixtures";
+import {
+  TEST_ACCOUNT_ADDRESS,
+  TEST_MAX_EPOCH,
+  TEST_NETWORK,
+  XTR_FAUCET_COMPONENT_ADDRESS,
+  XTR_RESOURCE,
+} from "./test/fixtures";
 
 const DESTINATION_ADDRESS = "component_" + "cc".repeat(32);
 
 describe("AccountInvokeBuilder", () => {
   it("publicTransfer emits a withdraw + saveVar + deposit instruction sequence", () => {
-    const tx = new AccountInvokeBuilder(TEST_NETWORK)
+    const tx = new AccountInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH)
       .publicTransfer(TEST_ACCOUNT_ADDRESS, XTR_RESOURCE, 500n, DESTINATION_ADDRESS)
       .build();
     // 500 = 0x01f4 → CBOR uint16 (0x19 0x01 0xf4), hi = 0 → array `[lo, hi]` = 8219 01f4 00.
@@ -24,7 +30,7 @@ describe("AccountInvokeBuilder", () => {
         CallMethod: {
           call: { Address: TEST_ACCOUNT_ADDRESS },
           method: "withdraw",
-          args: [resourceAddressLiteral(XTR_RESOURCE), { Literal: "821901f400" }],
+          args: [resourceAddressLiteral(XTR_RESOURCE), { Literal: "1901f4" }],
         },
       },
       { PutLastInstructionOutputOnWorkspace: { key: 0 } },
@@ -39,7 +45,7 @@ describe("AccountInvokeBuilder", () => {
   });
 
   it("publishTemplate emits a PublishTemplate instruction backed by a blob (not a method call)", () => {
-    const tx = new AccountInvokeBuilder(TEST_NETWORK)
+    const tx = new AccountInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1000n)
       .publishTemplate(TEST_ACCOUNT_ADDRESS, "QUJD")
       .build();
@@ -50,7 +56,7 @@ describe("AccountInvokeBuilder", () => {
 
 describe("AccountInvokeBuilder fee instructions", () => {
   it("feeTransactionPayFromComponent emits a pay_fee fee instruction", () => {
-    const tx = new AccountInvokeBuilder(TEST_NETWORK)
+    const tx = new AccountInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1_000n)
       .publicTransfer(TEST_ACCOUNT_ADDRESS, XTR_RESOURCE, 1n, DESTINATION_ADDRESS)
       .build();
@@ -59,7 +65,7 @@ describe("AccountInvokeBuilder fee instructions", () => {
         CallMethod: {
           call: { Address: TEST_ACCOUNT_ADDRESS },
           method: "pay_fee",
-          args: [{ Literal: "821903e800" }],
+          args: [{ Literal: "1903e8" }],
         },
       },
     ]);
@@ -68,16 +74,16 @@ describe("AccountInvokeBuilder fee instructions", () => {
 
 describe("FaucetInvokeBuilder", () => {
   it("takeFaucetFunds emits a take_free_coins + saveVar + deposit instruction sequence", () => {
-    const tx = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+    const tx = new FaucetInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH, XTR_FAUCET_COMPONENT_ADDRESS)
       .takeFaucetFunds(TEST_ACCOUNT_ADDRESS, 10_000n)
       .build();
-    // 10_000 = 0x2710 → CBOR uint16 (0x19 0x27 0x10), hi = 0 → array `[lo, hi]` = 8219 2710 00.
+    // 10_000 = 0x2710 → CBOR uint16: 0x19 0x27 0x10.
     expect(tx.instructions).toEqual([
       {
         CallMethod: {
           call: { Address: XTR_FAUCET_COMPONENT_ADDRESS },
           method: "take_free_coins",
-          args: [{ Literal: "8219271000" }],
+          args: [{ Literal: "192710" }],
         },
       },
       { PutLastInstructionOutputOnWorkspace: { key: 0 } },
@@ -92,7 +98,7 @@ describe("FaucetInvokeBuilder", () => {
   });
 
   it("takeMaxFaucetFunds emits take_max_free_coins with no amount arg", () => {
-    const tx = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+    const tx = new FaucetInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH, XTR_FAUCET_COMPONENT_ADDRESS)
       .takeMaxFaucetFunds(TEST_ACCOUNT_ADDRESS)
       .build();
     // Distinguished from takeFaucetFunds by the method name and the EMPTY arg list —
@@ -118,7 +124,7 @@ describe("FaucetInvokeBuilder", () => {
 
   it("publishTemplate calls `new` on the template and saves it under the default bucket", () => {
     const templateAddress = "template_" + "ab".repeat(32);
-    const tx = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+    const tx = new FaucetInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH, XTR_FAUCET_COMPONENT_ADDRESS)
       .publishTemplate(templateAddress)
       .build();
     // The faucet variant is a CallFunction on the template (unlike the Account
@@ -131,7 +137,7 @@ describe("FaucetInvokeBuilder", () => {
   });
 
   it("feeTransactionPayFromComponent adds a pay_fee FEE instruction, not a normal one", () => {
-    const tx = new FaucetInvokeBuilder(TEST_NETWORK, XTR_FAUCET_COMPONENT_ADDRESS)
+    const tx = new FaucetInvokeBuilder(TEST_NETWORK, TEST_MAX_EPOCH, XTR_FAUCET_COMPONENT_ADDRESS)
       .feeTransactionPayFromComponent(TEST_ACCOUNT_ADDRESS, 1_000n)
       .takeMaxFaucetFunds(TEST_ACCOUNT_ADDRESS)
       .build();
@@ -141,7 +147,7 @@ describe("FaucetInvokeBuilder", () => {
         CallMethod: {
           call: { Address: TEST_ACCOUNT_ADDRESS },
           method: "pay_fee",
-          args: [{ Literal: "821903e800" }],
+          args: [{ Literal: "1903e8" }],
         },
       },
     ]);

--- a/packages/ootle/src/builtin-templates.ts
+++ b/packages/ootle/src/builtin-templates.ts
@@ -19,7 +19,7 @@ import type { Network } from "./network";
  *
  * @example
  * ```ts
- * const tx = new AccountInvokeBuilder(network)
+ * const tx = new AccountInvokeBuilder(network, maxEpoch)
  *   .feeTransactionPayFromComponent(accountAddress, 1000n)
  *   .publicTransfer(accountAddress, resourceAddress, 500n, recipientAddress)
  *   .build();
@@ -28,8 +28,8 @@ import type { Network } from "./network";
 export class AccountInvokeBuilder {
   private builder: TransactionBuilder;
 
-  constructor(network: Network | number) {
-    this.builder = TransactionBuilder.new(network);
+  constructor(network: Network | number, maxEpoch: number) {
+    this.builder = TransactionBuilder.new(network, maxEpoch);
   }
 
   /**
@@ -100,7 +100,7 @@ export class AccountInvokeBuilder {
  *
  * @example
  * ```ts
- * const tx = new FaucetInvokeBuilder(network, faucetAddress)
+ * const tx = new FaucetInvokeBuilder(network, maxEpoch, faucetAddress)
  *   .feeTransactionPayFromComponent(accountAddress, 1000n)
  *   .takeFaucetFunds(accountAddress, 10_000n)
  *   .build();
@@ -110,8 +110,8 @@ export class FaucetInvokeBuilder {
   private builder: TransactionBuilder;
   private readonly faucetAddress: ComponentAddress;
 
-  constructor(network: Network | number, faucetAddress: ComponentAddress) {
-    this.builder = TransactionBuilder.new(network);
+  constructor(network: Network | number, maxEpoch: number, faucetAddress: ComponentAddress) {
+    this.builder = TransactionBuilder.new(network, maxEpoch);
     this.faucetAddress = faucetAddress;
   }
 

--- a/packages/ootle/src/exports.test.ts
+++ b/packages/ootle/src/exports.test.ts
@@ -29,6 +29,9 @@ import {
   InvalidArgumentError,
   // existing public surface
   TransactionBuilder,
+  MAX_TRANSACTION_VALIDITY_EPOCHS,
+  DEFAULT_TRANSACTION_VALIDITY_EPOCHS,
+  resolveMaxEpoch,
   OotleWallet,
   Network,
   toHexStr,
@@ -40,6 +43,12 @@ describe("@tari-project/ootle exports map resolution", () => {
     expect(typeof microTariLiteral).toBe("function");
     expect(typeof microTariString).toBe("function");
     expect(typeof assertByteLength).toBe("function");
+  });
+
+  it("resolves the epoch-window surface a builder needs", () => {
+    expect(typeof resolveMaxEpoch).toBe("function");
+    expect(MAX_TRANSACTION_VALIDITY_EPOCHS).toBe(2160);
+    expect(DEFAULT_TRANSACTION_VALIDITY_EPOCHS).toBeLessThan(MAX_TRANSACTION_VALIDITY_EPOCHS);
   });
 
   it("resolves the typed error hierarchy", () => {

--- a/packages/ootle/src/helpers/amount.test.ts
+++ b/packages/ootle/src/helpers/amount.test.ts
@@ -16,12 +16,12 @@ describe("microTariLiteral", () => {
     expect(microTariLiteral(1234n)).toEqual(amountLiteral(1234n));
   });
 
-  it("encodes 0n as the canonical [0, 0] CBOR array", () => {
-    expect(microTariLiteral(0n)).toEqual({ Literal: "820000" });
+  it("encodes 0n as a bare CBOR zero", () => {
+    expect(microTariLiteral(0n)).toEqual({ Literal: "00" });
   });
 
   it("encodes 2^64 - 1 without precision loss (above Number.MAX_SAFE_INTEGER)", () => {
-    expect(microTariLiteral(2n ** 64n - 1n)).toEqual({ Literal: "821bffffffffffffffff00" });
+    expect(microTariLiteral(2n ** 64n - 1n)).toEqual({ Literal: "1bffffffffffffffff" });
   });
 
   it("throws on a negative amount", () => {

--- a/packages/ootle/src/helpers/cbor-literal.test.ts
+++ b/packages/ootle/src/helpers/cbor-literal.test.ts
@@ -26,35 +26,43 @@ import {
   vaultIdLiteral,
 } from "./cbor-literal";
 
+// The expected bytes are minicbor's `Encoder::u128` output, which the runtime's
+// `impl Encode for Amount` delegates to — a plain CBOR integer inside the CBOR integer
+// range and a tag-2 unsigned bignum above it. Vectors mirror the table in tari-ootle
+// PR #2414, which introduced this encoding.
 describe("amountLiteral", () => {
-  it("encodes 0n as the two-element [0, 0] CBOR array", () => {
-    expect(amountLiteral(0n)).toEqual({ Literal: "820000" });
+  it("encodes 0n as a bare CBOR zero", () => {
+    expect(amountLiteral(0n)).toEqual({ Literal: "00" });
   });
 
-  it("encodes 1n as [1, 0] (lo_u64=1, hi_u64=0)", () => {
-    expect(amountLiteral(1n)).toEqual({ Literal: "820100" });
+  it("encodes 1n as a bare CBOR one", () => {
+    expect(amountLiteral(1n)).toEqual({ Literal: "01" });
   });
 
   it("encodes a 16-bit amount with the 0x19 length tag", () => {
-    // 1234 = 0x04d2 → 0x19 0x04 0xd2, hi = 0.
-    expect(amountLiteral(1234n)).toEqual({ Literal: "821904d200" });
+    // 1234 = 0x04d2 → 0x19 0x04 0xd2.
+    expect(amountLiteral(1234n)).toEqual({ Literal: "1904d2" });
   });
 
   it("encodes a 32-bit amount (1_000_000) with the 0x1a length tag", () => {
-    // 1_000_000 = 0x000f4240 → 0x1a 0x00 0x0f 0x42 0x40, hi = 0.
-    expect(amountLiteral(1_000_000n)).toEqual({ Literal: "821a000f424000" });
+    // 1_000_000 = 0x000f4240 → 0x1a 0x00 0x0f 0x42 0x40.
+    expect(amountLiteral(1_000_000n)).toEqual({ Literal: "1a000f4240" });
   });
 
-  it("encodes the largest u64 (2^64 - 1) lo with hi = 0", () => {
-    expect(amountLiteral(2n ** 64n - 1n)).toEqual({ Literal: "821bffffffffffffffff00" });
+  it("encodes the largest u64 (2^64 - 1) as a plain CBOR integer, not a bignum", () => {
+    expect(amountLiteral(2n ** 64n - 1n)).toEqual({ Literal: "1bffffffffffffffff" });
   });
 
-  it("encodes 2^64 as lo = 0, hi = 1", () => {
-    expect(amountLiteral(2n ** 64n)).toEqual({ Literal: "820001" });
+  it("encodes 2^64 as a tag-2 bignum of minimal length (9 bytes, not zero-padded to 16)", () => {
+    expect(amountLiteral(2n ** 64n)).toEqual({ Literal: "c249010000000000000000" });
   });
 
-  it("encodes 2^127 as lo = 0, hi = 2^63 (high bit set)", () => {
-    expect(amountLiteral(2n ** 127n)).toEqual({ Literal: "82001b8000000000000000" });
+  it("encodes 2^127 as a 16-byte tag-2 bignum (high bit set)", () => {
+    expect(amountLiteral(2n ** 127n)).toEqual({ Literal: "c25080000000000000000000000000000000" });
+  });
+
+  it("encodes u128::MAX as a 16-byte tag-2 bignum", () => {
+    expect(amountLiteral(2n ** 128n - 1n)).toEqual({ Literal: "c250" + "ff".repeat(16) });
   });
 
   it("throws on a negative amount", () => {

--- a/packages/ootle/src/helpers/cbor-literal.ts
+++ b/packages/ootle/src/helpers/cbor-literal.ts
@@ -26,6 +26,8 @@ import { assertByteLength } from "./bytes";
 import { fromHexStr, toHexStr } from "./hex";
 
 const U64_MASK = (1n << 64n) - 1n;
+// RFC 8949 tag 2: unsigned bignum, the form `minicbor` uses above the CBOR integer range.
+const BIGNUM_TAG_UNSIGNED = 2n;
 const OBJECT_KEY_LEN = 32;
 const OBJECT_KEY_HEX_LEN = OBJECT_KEY_LEN * 2;
 // A compressed Ristretto point is a bare 32-byte CBOR byte string (untagged).
@@ -79,8 +81,13 @@ export function literalArg(value: bigint | string | boolean | Uint8Array): Instr
 }
 
 /**
- * CBOR-encode an `Amount` (u128) as the `[lo_u64, hi_u64]` pair the runtime
- * deserialises via `tari_bor`.
+ * CBOR-encode an `Amount` (u128) the way the runtime's `minicbor` codec does:
+ * a plain CBOR unsigned integer while the value fits the CBOR integer range
+ * (`0..=u64::MAX`), and an RFC 8949 tag-2 unsigned bignum (minimal-length
+ * big-endian byte string) above it.
+ *
+ * Wire-breaking against the pre-0.39 `[lo_u64, hi_u64]` digit-array form —
+ * templates built against an older `tari_template_lib` cannot decode this.
  *
  * @throws {InvalidArgumentError} if `value` is negative or overflows u128.
  */
@@ -92,16 +99,35 @@ export function amountLiteral(value: bigint): InstructionArg {
     throw new InvalidArgumentError(`amountLiteral: amount overflows u128: ${value}`);
   }
   const out: number[] = [];
-  appendHead(out, MAJOR_ARRAY, 2n);
-  appendHead(out, MAJOR_UINT, value & U64_MASK);
-  appendHead(out, MAJOR_UINT, (value >> 64n) & U64_MASK);
+  if (value <= U64_MASK) {
+    appendHead(out, MAJOR_UINT, value);
+  } else {
+    appendBignum(out, value);
+  }
   return literal(out);
 }
 
 /**
+ * Append an RFC 8949 unsigned bignum: `Tag(2, bytes(<minimal big-endian>))`.
+ * `minicbor` emits the shortest byte string that represents the value, so a
+ * `u64::MAX + 1` is nine bytes, not a zero-padded sixteen.
+ */
+function appendBignum(out: number[], value: bigint): void {
+  const bytes: number[] = [];
+  let rest = value;
+  while (rest > 0n) {
+    bytes.unshift(Number(rest & 0xffn));
+    rest >>= 8n;
+  }
+  appendHead(out, MAJOR_TAG, BIGNUM_TAG_UNSIGNED);
+  appendHead(out, MAJOR_BYTES, BigInt(bytes.length));
+  appendBytes(out, bytes);
+}
+
+/**
  * CBOR-encode a plain integer (Rust `u8`…`u128` / `i8`…`i128`) as a bare CBOR
- * integer. Distinct from {@link amountLiteral}, which encodes the `Amount` type
- * as a two-element array.
+ * integer. Distinct from {@link amountLiteral} only above the CBOR integer
+ * range, where an `Amount` becomes a tag-2 bignum and this throws instead.
  *
  * @throws {InvalidArgumentError} if the magnitude exceeds the 64-bit CBOR
  *   integer range (128-bit bignum encoding is not supported).

--- a/packages/ootle/src/helpers/vault-walker.test.ts
+++ b/packages/ootle/src/helpers/vault-walker.test.ts
@@ -24,6 +24,7 @@ function taggedBytes(tag: number, hex: string) {
 function stubProvider(overrides: Partial<Provider> = {}): Provider {
   const base: Provider = {
     network: () => Network.LocalNet,
+    getCurrentEpoch: vi.fn(async () => 90),
     resolveInputs: vi.fn(),
     getSubstate: vi.fn(),
     getStealthUtxo: vi.fn(),

--- a/packages/ootle/src/index.ts
+++ b/packages/ootle/src/index.ts
@@ -4,7 +4,12 @@
 export { Network } from "./network";
 export type { Signer, SignerStealthCrypto } from "./signer";
 export type { Provider } from "./provider";
-export { TransactionBuilder } from "./builder";
+export {
+  TransactionBuilder,
+  MAX_TRANSACTION_VALIDITY_EPOCHS,
+  DEFAULT_TRANSACTION_VALIDITY_EPOCHS,
+  resolveMaxEpoch,
+} from "./builder";
 export type { TariFunctionDefinition, TariMethodDefinition, NamedArg, UnsignedTransactionWithBlobs } from "./builder";
 export {
   buildTransactionSignature,

--- a/packages/ootle/src/provider.ts
+++ b/packages/ootle/src/provider.ts
@@ -23,6 +23,16 @@ export interface Provider {
   /** Returns the network this provider is connected to. */
   network(): Network;
 
+  /**
+   * Returns the epoch the network is currently on.
+   *
+   * Every transaction carries a mandatory `max_epoch`, capped at
+   * `MAX_TRANSACTION_VALIDITY_EPOCHS` past this value, so a builder needs the chain tip
+   * before it can be constructed: `TransactionBuilder.new(network, await
+   * provider.getCurrentEpoch() + 10)`.
+   */
+  getCurrentEpoch(): Promise<number>;
+
   /** Fetches a single substate by ID and optional version. */
   getSubstate(substateId: string, version?: number | null): Promise<IndexerGetSubstateResponse>;
 

--- a/packages/ootle/src/stealth/authorizer.revealed.test.ts
+++ b/packages/ootle/src/stealth/authorizer.revealed.test.ts
@@ -171,10 +171,11 @@ describe("patchStealthStatement", () => {
       instructions: ["DropAllProofsInWorkspace"],
       inputs: [],
       min_epoch: null,
-      max_epoch: null,
+      max_epoch: 100,
       dry_run: false,
       is_seal_signer_authorized: false,
       blobs: [],
+      nonce: 0,
     };
     // A real (incomplete) statement; the throw happens during instruction lookup.
     expect(() => patchStealthStatement(tx, spec.statement)).toThrow(/not a stealth tx/);

--- a/packages/ootle/src/stealth/authorizer.spend.test.ts
+++ b/packages/ootle/src/stealth/authorizer.spend.test.ts
@@ -171,6 +171,7 @@ class TestSigner implements Signer {
 function stubProvider(overrides: Partial<Provider> = {}): Provider {
   const base: Provider = {
     network: () => Network.LocalNet,
+    getCurrentEpoch: vi.fn(async () => 90),
     resolveInputs: vi.fn(async (inputs: SubstateRequirement[]) =>
       inputs.map((i) => ({ ...i, version: i.version ?? 0 })),
     ),

--- a/packages/ootle/src/stealth/instruction.wasm.test.ts
+++ b/packages/ootle/src/stealth/instruction.wasm.test.ts
@@ -67,10 +67,11 @@ function txWithStatement(statement: unknown): UnsignedTransactionV1 {
     ],
     inputs: [],
     min_epoch: null,
-    max_epoch: null,
+    max_epoch: 100,
     dry_run: false,
     is_seal_signer_authorized: false,
     blobs: [],
+    nonce: 0,
   };
 }
 

--- a/packages/ootle/src/stealth/transfer.spend.test.ts
+++ b/packages/ootle/src/stealth/transfer.spend.test.ts
@@ -29,6 +29,7 @@ const COMMITMENT_B = fromHexStr("22".repeat(32));
 function stubProvider(overrides: Partial<Provider> = {}): Provider {
   const base: Provider = {
     network: () => Network.LocalNet,
+    getCurrentEpoch: vi.fn(async () => 90),
     resolveInputs: vi.fn(async (inputs: SubstateRequirement[]) =>
       inputs.map((i) => ({ ...i, version: i.version ?? 0 })),
     ),

--- a/packages/ootle/src/stealth/transfer.test.ts
+++ b/packages/ootle/src/stealth/transfer.test.ts
@@ -9,6 +9,7 @@
 
 import type { SubstateRequirement } from "@tari-project/ootle-ts-bindings";
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_TRANSACTION_VALIDITY_EPOCHS } from "../builder";
 import { Network } from "../network";
 import type { Provider } from "../provider";
 import { FakeStealthCrypto } from "../test/fake-crypto";
@@ -26,6 +27,7 @@ const DESTINATION = "account_dest_address";
 function stubProvider(overrides: Partial<Provider> = {}): Provider {
   const base: Provider = {
     network: () => Network.LocalNet,
+    getCurrentEpoch: vi.fn(async () => 90),
     // `resolveInputs` echoes inputs back with version filled in (the only path prepare hits).
     resolveInputs: vi.fn(async (inputs: SubstateRequirement[]) =>
       inputs.map((i) => ({ ...i, version: i.version ?? 0 })),
@@ -65,13 +67,13 @@ describe("StealthTransfer.prepare", () => {
     expect(instrs.length).toBe(3);
 
     // 1. revealed withdraw is a CallMethod "withdraw" with BOR-CBOR Literal args:
-    //    resource address as Tag(131, bytes(32)), amount as [lo_u64, hi_u64].
+    //    resource address as Tag(131, bytes(32)), amount as a bare CBOR integer.
     //    RESOURCE = "resource_" + "a".repeat(64); 1000 = 0x03e8 → uint16 (0x19 0x03 0xe8).
     const withdraw = instrs[0];
     expect(withdraw).toHaveProperty("CallMethod");
     if (typeof withdraw !== "object" || !("CallMethod" in withdraw)) throw new Error("expected CallMethod");
     expect(withdraw.CallMethod.method).toBe("withdraw");
-    expect(withdraw.CallMethod.args).toEqual([{ Literal: "d8835820" + "a".repeat(64) }, { Literal: "821903e800" }]);
+    expect(withdraw.CallMethod.args).toEqual([{ Literal: "d8835820" + "a".repeat(64) }, { Literal: "1903e8" }]);
 
     // 2. saveVar (PutLastInstructionOutputOnWorkspace).
     expect(instrs[1]).toHaveProperty("PutLastInstructionOutputOnWorkspace");
@@ -245,5 +247,36 @@ describe("StealthTransfer.prepare", () => {
 
     await transfer.prepare();
     await expect(transfer.prepare()).rejects.toThrow(/already prepared/);
+  });
+
+  // The builder needs `max_epoch` at construction, but the chain tip only becomes
+  // reachable inside the async `prepare()` — so the window is stamped there.
+  it("stamps max_epoch from the chain tip during prepare()", async () => {
+    const crypto = new FakeStealthCrypto();
+    const getCurrentEpoch = vi.fn(async () => 90);
+    const provider = stubProvider({ getCurrentEpoch });
+
+    const spec = await new StealthTransfer(provider, RESOURCE, crypto)
+      .spendRevealedInput(ACCOUNT, 1000n)
+      .toStealthOutput(createOutput({ destination: DESTINATION, amount: 1000n, resourceAddress: RESOURCE }))
+      .prepare();
+
+    expect(getCurrentEpoch).toHaveBeenCalledOnce();
+    expect(spec.unsignedTx.max_epoch).toBe(90 + DEFAULT_TRANSACTION_VALIDITY_EPOCHS);
+  });
+
+  it("withMaxEpoch overrides the window and skips the chain-tip lookup", async () => {
+    const crypto = new FakeStealthCrypto();
+    const getCurrentEpoch = vi.fn(async () => 90);
+    const provider = stubProvider({ getCurrentEpoch });
+
+    const spec = await new StealthTransfer(provider, RESOURCE, crypto)
+      .withMaxEpoch(555)
+      .spendRevealedInput(ACCOUNT, 1000n)
+      .toStealthOutput(createOutput({ destination: DESTINATION, amount: 1000n, resourceAddress: RESOURCE }))
+      .prepare();
+
+    expect(getCurrentEpoch).not.toHaveBeenCalled();
+    expect(spec.unsignedTx.max_epoch).toBe(555);
   });
 });

--- a/packages/ootle/src/stealth/transfer.ts
+++ b/packages/ootle/src/stealth/transfer.ts
@@ -10,7 +10,7 @@
 // then signs the balance proof, hydrates the statement, and seals.
 
 import type { ComponentAddress, ResourceAddress, UnsignedTransactionV1 } from "@tari-project/ootle-ts-bindings";
-import { TransactionBuilder } from "../builder";
+import { TransactionBuilder, resolveMaxEpoch } from "../builder";
 import type { Provider } from "../provider";
 import { resolveTransaction } from "../transaction";
 import { amountLiteral, resourceAddressLiteral } from "../helpers/cbor-literal";
@@ -78,6 +78,13 @@ export interface StealthTransferSpec {
 }
 
 /**
+ * Placeholder `max_epoch` the inner builder is constructed with, replaced in
+ * {@link StealthTransfer.prepare}. Epoch 0 is in the distant past on every live network,
+ * so a window that somehow escaped unstamped expires rather than being accepted.
+ */
+const PENDING_MAX_EPOCH = 0;
+
+/**
  * Fluent builder for a confidential (stealth) transfer.
  *
  * Supports the full input/output matrix: spend revealed input (withdraw from a vault)
@@ -101,6 +108,8 @@ export class StealthTransfer {
   private readonly crypto: StealthCryptoProvider;
   private builder: TransactionBuilder;
   private readonly state: StealthTransferState;
+  /** Set by {@link withMaxEpoch}; `null` means {@link prepare} resolves one from the chain tip. */
+  private maxEpoch: number | null = null;
   /** Guards against a second {@link prepare} re-emitting instructions into the same builder. */
   private prepared = false;
 
@@ -117,7 +126,10 @@ export class StealthTransfer {
   ) {
     this.provider = provider;
     this.crypto = crypto;
-    this.builder = TransactionBuilder.new(provider.network());
+    // `max_epoch` is mandatory but depends on the chain tip, which only an `await` can
+    // reach — so it is stamped in `prepare()` (from `withMaxEpoch`, else `resolveMaxEpoch`)
+    // rather than here. Nothing between now and then reads it.
+    this.builder = TransactionBuilder.new(provider.network(), PENDING_MAX_EPOCH);
     this.state = {
       resource: resourceAddress,
       revealedInput: null,
@@ -182,6 +194,19 @@ export class StealthTransfer {
       throw new InvalidArgumentError(`payFeeFromRevealed amount must be > 0, got ${amount}`);
     }
     this.builder.feeTransactionPayFromComponent(this.state.revealedInput.source, amount);
+    return this;
+  }
+
+  /**
+   * Set the transaction's validity window explicitly. Without this, {@link prepare}
+   * reads the current epoch from the provider and applies
+   * `DEFAULT_TRANSACTION_VALIDITY_EPOCHS`.
+   *
+   * @throws {InvalidArgumentError} if `maxEpoch` is not a non-negative integer.
+   */
+  public withMaxEpoch(maxEpoch: number): this {
+    this.builder.withMaxEpoch(maxEpoch);
+    this.maxEpoch = maxEpoch;
     return this;
   }
 
@@ -283,6 +308,12 @@ export class StealthTransfer {
 
     // 4. Emit instructions.
     this.emitInstructions(statement);
+
+    // Stamp the validity window now that we can await the chain tip. `withBuilder` may
+    // have set one directly on the inner builder, so only default an untouched sentinel.
+    if (this.maxEpoch === null && this.builder.buildUnsignedTransaction().max_epoch === PENDING_MAX_EPOCH) {
+      this.builder.withMaxEpoch(await resolveMaxEpoch(this.provider));
+    }
 
     const declaredInputs = new Set<string>();
 

--- a/packages/ootle/src/test/fake-provider.ts
+++ b/packages/ootle/src/test/fake-provider.ts
@@ -10,7 +10,7 @@
 import { vi } from "vitest";
 import type { SubstateRequirement } from "@tari-project/ootle-ts-bindings";
 import type { Provider } from "../provider";
-import { TEST_NETWORK } from "./fixtures";
+import { TEST_MAX_EPOCH, TEST_NETWORK } from "./fixtures";
 
 /**
  * Construct a {@link Provider} test double. Every method is a `vi.fn()`;
@@ -25,6 +25,7 @@ import { TEST_NETWORK } from "./fixtures";
 export function fakeProvider(overrides: Partial<Provider> = {}): Provider {
   const base: Provider = {
     network: () => TEST_NETWORK,
+    getCurrentEpoch: vi.fn(async () => TEST_MAX_EPOCH - 10),
     resolveInputs: vi.fn(async (inputs: SubstateRequirement[]) =>
       inputs.map((i) => ({ ...i, version: i.version ?? 0 })),
     ),

--- a/packages/ootle/src/test/fake-signer.wasm.test.ts
+++ b/packages/ootle/src/test/fake-signer.wasm.test.ts
@@ -57,10 +57,11 @@ async function stealthTx(): Promise<UnsignedTransactionV1> {
     ],
     inputs: [],
     min_epoch: null,
-    max_epoch: null,
+    max_epoch: 100,
     dry_run: false,
     is_seal_signer_authorized: false,
     blobs: [],
+    nonce: 0,
   } as UnsignedTransactionV1;
 }
 

--- a/packages/ootle/src/test/fixtures.ts
+++ b/packages/ootle/src/test/fixtures.ts
@@ -31,6 +31,13 @@ export const SEAL_PUBLIC = fromHexStr("0f".repeat(32));
 export const TEST_NETWORK = Network.LocalNet;
 
 /**
+ * The `max_epoch` every test uses unless it explicitly varies it. `max_epoch` is
+ * mandatory on `UnsignedTransactionV1`, so every builder needs one; the value only
+ * matters to tests that assert on the validity window itself.
+ */
+export const TEST_MAX_EPOCH = 100;
+
+/**
  * A syntactically-valid resource address (the canonical XTR/TARI resource), and
  * the LocalNet faucet component address. Re-exported here so a single import
  * line in a test file covers both keys and on-chain addresses.

--- a/packages/ootle/src/test/tx-builders.ts
+++ b/packages/ootle/src/test/tx-builders.ts
@@ -11,15 +11,18 @@ import type {
 } from "@tari-project/ootle-ts-bindings";
 import { TransactionBuilder } from "../builder";
 import type { Network } from "../network";
-import { TEST_NETWORK } from "./fixtures";
+import { TEST_MAX_EPOCH, TEST_NETWORK } from "./fixtures";
 
 /**
  * The smallest valid `UnsignedTransactionV1` — a single `DropAllProofsInWorkspace`
  * instruction. Useful when a test only cares about the sign/seal flow, not the
  * instruction set itself.
  */
-export function trivialUnsignedTx(network: Network = TEST_NETWORK): UnsignedTransactionV1 {
-  return TransactionBuilder.new(network).dropAllProofsInWorkspace().buildUnsignedTransaction();
+export function trivialUnsignedTx(
+  network: Network = TEST_NETWORK,
+  maxEpoch: number = TEST_MAX_EPOCH,
+): UnsignedTransactionV1 {
+  return TransactionBuilder.new(network, maxEpoch).dropAllProofsInWorkspace().buildUnsignedTransaction();
 }
 
 /** The `final_decision` union of a `Finalized` transaction result. */

--- a/packages/ootle/src/transaction.seal-precision.wasm.test.ts
+++ b/packages/ootle/src/transaction.seal-precision.wasm.test.ts
@@ -72,10 +72,11 @@ function txWithStatement(statement: unknown): UnsignedTransactionV1 {
     ],
     inputs: [],
     min_epoch: null,
-    max_epoch: null,
+    max_epoch: 100,
     dry_run: false,
     is_seal_signer_authorized: false,
     blobs: [],
+    nonce: 0,
   } as UnsignedTransactionV1;
 }
 

--- a/packages/ootle/src/transaction.smoke.test.ts
+++ b/packages/ootle/src/transaction.smoke.test.ts
@@ -2,7 +2,7 @@
 //   SPDX-License-Identifier: BSD-3-Clause
 
 // No-network smoke test for the existing (non-stealth) transaction flow on
-// `@tari-project/ootle-wasm@0.38.0`. It builds a tiny UnsignedTransactionV1, signs it,
+// `@tari-project/ootle-wasm@0.39.0`. It builds a tiny UnsignedTransactionV1, signs it,
 // and seals it — proving `generateKeypair` + `hashUnsignedTransaction` + `schnorrSign`
 // + `borEncodeTransaction` still work after the bump, with no regression.
 //
@@ -13,12 +13,14 @@
 // same WASM crypto path (`generateKeypair` → `hashUnsignedTransaction` → `schnorrSign`).
 import { describe, expect, it } from "vitest";
 import { Network } from "./network";
-import { sealTransaction, signTransaction } from "./transaction";
+import { sealTransaction, serializeUnsignedTx, signTransaction } from "./transaction";
+import { TransactionBuilder } from "./builder";
+import { TEST_MAX_EPOCH } from "./test/fixtures";
 import { InlineEphemeralSigner } from "./test/fake-signer";
 import { trivialUnsignedTx } from "./test/tx-builders";
 
 describe("transaction sign + seal smoke test (no network)", () => {
-  it("signs and seals a minimal transaction after the 0.38 bump", async () => {
+  it("signs and seals a minimal transaction after the 0.39 bump", async () => {
     const signer = InlineEphemeralSigner.generate();
 
     const unsignedTx = trivialUnsignedTx(Network.LocalNet);
@@ -31,5 +33,29 @@ describe("transaction sign + seal smoke test (no network)", () => {
     const envelope = sealTransaction(signed);
     expect(typeof envelope, "sealTransaction must return a base64 TransactionEnvelope string").toBe("string");
     expect(envelope.length, "the sealed envelope must be non-empty").toBeGreaterThan(0);
+  });
+
+  // `nonce` is a u64: above `Number.MAX_SAFE_INTEGER` the builder keeps it as a bigint,
+  // which `JSON.stringify` cannot emit at all now that the clients no longer patch
+  // `BigInt.prototype.toJSON`. `serializeUnsignedTx` emits it as a decimal string, which
+  // the Rust side's `str_number` adapter accepts — this proves the WASM hasher agrees.
+  it("signs and seals a transaction whose nonce exceeds Number.MAX_SAFE_INTEGER", async () => {
+    const signer = InlineEphemeralSigner.generate();
+    const unsignedTx = TransactionBuilder.new(Network.LocalNet, TEST_MAX_EPOCH)
+      .withNonce(2n ** 64n - 1n)
+      .dropAllProofsInWorkspace()
+      .buildUnsignedTransaction();
+
+    expect(serializeUnsignedTx(unsignedTx)).toContain('"nonce":"18446744073709551615"');
+
+    const signed = await signTransaction([signer], unsignedTx);
+    expect(sealTransaction(signed).length).toBeGreaterThan(0);
+  });
+
+  it("gives two transactions differing only in nonce distinct signing preimages", async () => {
+    const base = TransactionBuilder.new(Network.LocalNet, TEST_MAX_EPOCH).dropAllProofsInWorkspace();
+    const a = base.withNonce(1).buildUnsignedTransaction();
+    const b = base.withNonce(2).buildUnsignedTransaction();
+    expect(serializeUnsignedTx(a)).not.toBe(serializeUnsignedTx(b));
   });
 });

--- a/packages/ootle/src/transaction.ts
+++ b/packages/ootle/src/transaction.ts
@@ -34,11 +34,20 @@ import type { RawJsonFragment } from "./stealth/instruction";
  * losslessly. We therefore stringify each carrier as a unique placeholder, then splice the raw
  * fragment in place of the quoted placeholder, never round-tripping the amounts through a JS
  * number.
+ *
+ * Any `bigint` field (e.g. a large `nonce`) is emitted as a decimal *string*, matching the
+ * Tari clients' wire encoding: every 64-bit field on these APIs accepts a string as well as a
+ * number, and a string is the only lossless encoding above `Number.MAX_SAFE_INTEGER`. Plain
+ * `JSON.stringify` throws on a `bigint`, and the global `BigInt.prototype.toJSON` patch the
+ * client packages used to install was removed in 0.39.
  */
 export function serializeUnsignedTx(unsignedTx: UnsignedTransactionV1): string {
   const fragments: string[] = [];
   const placeholderFor = (i: number): string => `__ootleRawJson:${i}__`;
   const serialized = JSON.stringify(unsignedTx, (_key, value: unknown) => {
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
     if (typeof value === "object" && value !== null && RAW_JSON_FRAGMENT in value) {
       const placeholder = placeholderFor(fragments.length);
       fragments.push((value as RawJsonFragment)[RAW_JSON_FRAGMENT]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,17 +13,17 @@ catalogs:
       specifier: ^7.57.7
       version: 7.57.7
     '@tari-project/indexer-client':
-      specifier: ^1.4.2
-      version: 1.4.2
+      specifier: ^1.6.0
+      version: 1.6.0
     '@tari-project/ootle-ts-bindings':
-      specifier: ^1.47.1
-      version: 1.47.1
+      specifier: ^1.49.1
+      version: 1.49.1
     '@tari-project/ootle-wasm':
-      specifier: ^0.38.0
-      version: 0.38.0
+      specifier: ^0.39.0
+      version: 0.39.0
     '@tari-project/wallet_jrpc_client':
-      specifier: ^1.20.0
-      version: 1.20.0
+      specifier: ^1.22.0
+      version: 1.22.0
     '@types/node':
       specifier: ^25.5.0
       version: 25.5.0
@@ -140,7 +140,7 @@ importers:
         version: link:../../packages/ootle-indexer
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -260,10 +260,10 @@ importers:
         version: link:../../packages/ootle-secret-key-wallet
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.38.0
+        version: 0.39.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -294,10 +294,10 @@ importers:
         version: link:../../packages/ootle-secret-key-wallet
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.38.0
+        version: 0.39.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -380,10 +380,10 @@ importers:
     dependencies:
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.38.0
+        version: 0.39.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -414,13 +414,13 @@ importers:
     dependencies:
       '@tari-project/indexer-client':
         specifier: 'catalog:'
-        version: 1.4.2
+        version: 1.6.0
       '@tari-project/ootle':
         specifier: 'workspace:'
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -454,10 +454,10 @@ importers:
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
       '@tari-project/ootle-wasm':
         specifier: 'catalog:'
-        version: 0.38.0
+        version: 0.39.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -491,10 +491,10 @@ importers:
         version: link:../ootle
       '@tari-project/ootle-ts-bindings':
         specifier: 'catalog:'
-        version: 1.47.1
+        version: 1.49.1
       '@tari-project/wallet_jrpc_client':
         specifier: 'catalog:'
-        version: 1.20.0
+        version: 1.22.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
@@ -2063,17 +2063,17 @@ packages:
   '@swc/wasm@1.15.18':
     resolution: {integrity: sha512-zeSORFArxqUwfVMTRHu8AN9k9LlfSn0CKDSzLhJDITpgLoS0xpnocxsgMjQjUcVYDgO47r9zLP49HEjH/iGsFg==}
 
-  '@tari-project/indexer-client@1.4.2':
-    resolution: {integrity: sha512-MR0VaDunbjMYbAW9IJHT7OXOLcdRu7X7FAq0IkG8nGSF8Mz0HIh3hueazVvkyjSg56T0EZ/qdv0a+2mURqo5Uw==}
+  '@tari-project/indexer-client@1.6.0':
+    resolution: {integrity: sha512-eIiWmnX9U73mbXY82LTFg7/fEFZ1KnNxH1qcllqPQinjCYUKCGf3fw4Ks0M1AUteOygO8yDRAuZ33eWPoLrrnA==}
 
-  '@tari-project/ootle-ts-bindings@1.47.1':
-    resolution: {integrity: sha512-g3VBXPwKNWAinWQwzMP1HL7oyK95Gvo5GvdUngpeQwqspW95QaGcRblVPHOOWxB+YiNtWN92kkxZ2GfGqmdQCw==}
+  '@tari-project/ootle-ts-bindings@1.49.1':
+    resolution: {integrity: sha512-B2WsiLZA/Csf3W5tCNU3qnos/HoLdvSzUczp3dDw4aY/jVafZLsvb8uwIomVoO+SmqhNzvRqBJDl63xm53SC6A==}
 
-  '@tari-project/ootle-wasm@0.38.0':
-    resolution: {integrity: sha512-vQgjW+XFxX0nsg5Gf22SfQh48i7TW2y5WWoyliMFJGga1XHt7iPr603uI2GBcb/6GenI8qJ2/1A+W7OoP77fIg==}
+  '@tari-project/ootle-wasm@0.39.0':
+    resolution: {integrity: sha512-/j8VmKUeJg+D2KvrVqoqklcKjzlnCcDGCChUDUpE62CjgJjI0ixHj4trxxDrCsM+wUL217aPjB8QQyfrFfL88Q==}
 
-  '@tari-project/wallet_jrpc_client@1.20.0':
-    resolution: {integrity: sha512-car8Qp0xmtj9HdDXy0N97bBMbmo2kENx+JD+MuUkAN+ngee7/q3qb0cVe6gPr32Wxp0uVjJcW81rzosThsMs8w==}
+  '@tari-project/wallet_jrpc_client@1.22.0':
+    resolution: {integrity: sha512-nNPeX2Zhu/8wxAhNdgJkHHBIehWoZB8dN3/OyY6asCzNDEtauVYhm+3bD2rOgBzYSOOrL3Su9ojxeWVizftL2Q==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -5515,19 +5515,19 @@ snapshots:
 
   '@swc/wasm@1.15.18': {}
 
-  '@tari-project/indexer-client@1.4.2':
+  '@tari-project/indexer-client@1.6.0':
     dependencies:
-      '@tari-project/ootle-ts-bindings': 1.47.1
+      '@tari-project/ootle-ts-bindings': 1.49.1
 
-  '@tari-project/ootle-ts-bindings@1.47.1':
+  '@tari-project/ootle-ts-bindings@1.49.1':
     dependencies:
       bech32: 2.0.0
 
-  '@tari-project/ootle-wasm@0.38.0': {}
+  '@tari-project/ootle-wasm@0.39.0': {}
 
-  '@tari-project/wallet_jrpc_client@1.20.0':
+  '@tari-project/wallet_jrpc_client@1.22.0':
     dependencies:
-      '@tari-project/ootle-ts-bindings': 1.47.1
+      '@tari-project/ootle-ts-bindings': 1.49.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,10 +8,10 @@ packages:
 catalog:
   "@eslint/js": ^10.0.1
   "@microsoft/api-extractor": ^7.57.7
-  "@tari-project/indexer-client": ^1.4.2
-  "@tari-project/ootle-ts-bindings": ^1.47.1
-  "@tari-project/ootle-wasm": ^0.38.0
-  "@tari-project/wallet_jrpc_client": ^1.20.0
+  "@tari-project/indexer-client": ^1.6.0
+  "@tari-project/ootle-ts-bindings": ^1.49.1
+  "@tari-project/ootle-wasm": ^0.39.0
+  "@tari-project/wallet_jrpc_client": ^1.22.0
   "@types/node": ^25.5.0
   eslint: ^10.0.3
   eslint-config-prettier: ^10.1.8


### PR DESCRIPTION
## Description

Bumps the catalog to `ootle-ts-bindings` 1.49.1, `ootle-wasm` 0.39.0, `indexer-client` 1.6.0 and `wallet_jrpc_client` 1.22.0, and carries the wire-breaking changes from the tari-ootle 0.39.0 release into the SDK.

**`max_epoch` is mandatory** (tari-ootle #2419). It is now a constructor argument, mirroring Rust's `Transaction::builder(network, max_epoch)`:

- `TransactionBuilder.new(network, maxEpoch)`
- `new AccountInvokeBuilder(network, maxEpoch)`
- `new FaucetInvokeBuilder(network, maxEpoch, faucetAddress)`

Deriving one needs the chain tip, so `Provider` gains `getCurrentEpoch()` (implemented on `IndexerProvider` via `epochManagerStats`), and the package exports `resolveMaxEpoch(provider, leadEpochs?)` alongside `MAX_TRANSACTION_VALIDITY_EPOCHS` (2160) and `DEFAULT_TRANSACTION_VALIDITY_EPOCHS` (10):

```ts
const builder = TransactionBuilder.new(provider.network(), await resolveMaxEpoch(provider));
```

`StealthTransfer` keeps its constructor — it stamps the window inside `prepare()`, the first point where the tip is awaitable — and `withMaxEpoch()` overrides it.

**`nonce` is a new field** in the signing and id domains. Defaults to `0`; `builder.withNonce(n)` accepts a number or bigint, validates u64, and keeps values above `Number.MAX_SAFE_INTEGER` as a bigint so they survive serialization.

**`Amount` changes CBOR encoding** (tari-ootle #2414): minicbor's native `u128` — a plain CBOR integer up to `u64::MAX`, an RFC 8949 tag-2 minimal-length bignum above — instead of the `[lo_u64, hi_u64]` digit array. `amountLiteral` and the examples' `amountLiteralHex` follow; vectors match the table in that PR.

**The client packages no longer patch `BigInt.prototype.toJSON`** (tari-ootle #2420), so `serializeUnsignedTx` emits bigints as decimal strings — which every 64-bit field accepts via `ootle_serde`'s `str_number` adapter, and which is the only lossless encoding above 2^53.

Checked and needing no change: `Instruction::EmitLog`, `TransactionReceipt.logs`, `StealthValueProof` → `CommitmentValueProof` and the reworked `ValueKnowledgeProof` are all unreferenced here; the 8 → 16 stealth-output cap is engine-side (`limits::max_outputs`), not enforced client-side; `AbortReason::ValidityWindowTooLong` flows through the existing string-based `TransactionRejectedError`.

Not included: the three new WASM exports for spending `PayTo::Conditions` outputs (`buildScriptPathWitness`, `buildStealthInputsStatementFromInputs`, `buildStealthTransferStatement`). Wiring those into the `StealthCryptoProvider` seam is a new HTLC/covenant-spending feature surface rather than an upgrade fix, so it is left for a follow-up.

Bumps the workspace to **0.3.0** (`pnpm version:set`), since 0.2.0 is already on npm and publishing is tag-driven — merging alone stages nothing without a version to tag. Breaking pre-1.0, so a minor bump, matching 0.1.0 → 0.2.0 for the previous protocol upgrade in #120.

Also fixes a pre-existing unnarrowed `Rejected` variant in `examples/node/src/workspace-chain.ts` — that package has no build or typecheck script, so nothing was catching it.

## Motivation and Context

Keeps the SDK able to build transactions the current protocol accepts. A transaction without `max_epoch` is no longer valid, and the pre-0.39 `Amount` encoding no longer decodes.

## How Has This Been Tested?

- `./scripts/check_versions.sh` clean at 0.3.0.
- `pnpm -r build`, `pnpm -r test` (356 / 59 / 23 / 16 / 2), `pnpm lint` and `prettier --check` all clean.
- New coverage: constructor and `withMaxEpoch`/`withMinEpoch` epoch validation, `withNonce` bounds and bigint retention, `withUnsignedTransaction` adopt behaviour for both new fields, nested fee-builder window inheritance, `resolveMaxEpoch` lead-epoch bounds, `IndexerProvider.getCurrentEpoch`, `StealthTransfer` window stamping, and `amountLiteral` vectors across the `u64::MAX` bignum boundary up to `u128::MAX`.
- The `.wasm.test.ts` suites exercise real WASM: one signs and seals a transaction whose nonce is `u64::MAX`, proving the hasher accepts the string-encoded bigint.

## Breaking Changes

- [ ] None
- [x] Please specify

- `TransactionBuilder`, `AccountInvokeBuilder` and `FaucetInvokeBuilder` require a `maxEpoch` argument.
- `Provider` implementations must add `getCurrentEpoch()`.
- `Amount` instruction literals change encoding — **templates must be rebuilt and republished against the current `tari_template_lib`**, and a testnet reset is required (transaction ids, `TransactionReceipt` and the fee tables all changed upstream).

<!-- BREAKING CHANGE: TransactionBuilder/AccountInvokeBuilder/FaucetInvokeBuilder require a maxEpoch argument; Provider implementations must add getCurrentEpoch(); Amount instruction literals change encoding, so templates must be rebuilt against the current tari_template_lib. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01699omq2rFke3wefJkUPK83
